### PR TITLE
Add documentation, make the poly traits more ergonomic, slot aliases for serde, support Anything, new rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ Pipfile.lock
 
 # User defined
 .vscode/*
+
+examples/PersonSchema/rust/target
+examples/PersonSchema/rust/Cargo.lock

--- a/docs/generators/index.rst
+++ b/docs/generators/index.rst
@@ -80,6 +80,7 @@ languages such as Python, Javascript, or Java.
    pydantic
    java
    typescript
+   rust
 
 Database
 --------

--- a/docs/generators/rust.rst
+++ b/docs/generators/rust.rst
@@ -8,7 +8,11 @@ Rust
 Example Output
 --------------
 
-`personinfo_pydantic.py <https://github.com/linkml/linkml/tree/main/examples/PersonSchema/personinfo_pydantic.py>`_
+The structs:
+`lib.rs <https://github.com/linkml/linkml/tree/main/examples/PersonSchema/rust/src/lib.rs>`_
+
+The traits:
+`poly.rs <https://github.com/linkml/linkml/tree/main/examples/PersonSchema/rust/src/poly.rs>`_
 
 Overview
 --------
@@ -16,8 +20,9 @@ Overview
 The Rust Generator produces a Rust crate with structs and enums from a LinkML model, with optional pyo3 and serde support.
 It additionally generates a trait for every struct to provide polymorphic access, in the `poly.rs` file.
 
-The Pydantic Generator produces Pydantic flavored python dataclasses from a linkml model,
-with optional support for user-supplied jinja2 templates to generate alternate classes.
+For all classes having subclasses, an extra enum is generated to represent an object of the class or a subtype. 
+All the enums implement the trait, so they can be (optionally) directly used without match statement.
+
 
 
 Example
@@ -28,262 +33,149 @@ Given a definition of a Person class:
 .. code-block:: yaml
 
      
-    Person:
-      is_a: NamedThing
-      description: >-
-        A person (alive, dead, undead, or fictional).
-      class_uri: schema:Person
-      mixins:
-        - HasAliases
-      slots:
-        - primary_email
-        - birth_date
-        - age_in_years
-        - gender
-        - current_address
-        - has_employment_history
-        - has_familial_relationships
-        - has_medical_history
+  Event:
+    slots:
+      - started_at_time
+      - ended_at_time
+      - duration
+      - is_current
 
-(some details omitted for brevity, including slot definitions and
-parent classes)
+  EmploymentEvent:
+    is_a: Event
+    slots:
+      - employed_at
 
-The generate python looks like this:
+  MedicalEvent:
+    is_a: Event
+    slots:
+      - in_location
+      - diagnosis
+      - procedure
 
-.. code-block:: python
 
-             
-    class Person(NamedThing):
-        """
-        A person (alive, dead, undead, or fictional).
-        """
-        primary_email: Optional[str] = Field(None)
-        birth_date: Optional[str] = Field(None)
-        age_in_years: Optional[int] = Field(None, ge=0, le=999)
-        gender: Optional[GenderType] = Field(None)
-        current_address: Optional[Address] = Field(None, description="""The address at which a person currently lives""")
-        has_employment_history: Optional[List[EmploymentEvent]] = Field(None)
-        has_familial_relationships: Optional[List[FamilialRelationship]] = Field(None)
-        has_medical_history: Optional[List[MedicalEvent]] = Field(None)
-        aliases: Optional[List[str]] = Field(None)
-        id: Optional[str] = Field(None)
-        name: Optional[str] = Field(None)
-        description: Optional[str] = Field(None)
-        image: Optional[str] = Field(None)
+
+The generate rust looks like this (serde and pyo3 annotations omitted for brevity):
+
+.. code-block:: rust
+
+
+    pub struct Event {
+        pub started_at_time: Option<NaiveDate>,
+        pub ended_at_time: Option<NaiveDate>,
+        pub duration: Option<f64>,
+        pub is_current: Option<bool>
+    }
+
+    pub struct EmploymentEvent {
+        pub employed_at: Option<String>,
+        pub started_at_time: Option<NaiveDate>,
+        pub ended_at_time: Option<NaiveDate>,
+        pub duration: Option<f64>,
+        pub is_current: Option<bool>
+    }
+
+    pub struct MedicalEvent {
+        pub in_location: Option<String>,
+        pub diagnosis: Option<DiagnosisConcept>,
+        pub procedure: Option<ProcedureConcept>,
+        pub started_at_time: Option<NaiveDate>,
+        pub ended_at_time: Option<NaiveDate>,
+        pub duration: Option<f64>,
+        pub is_current: Option<bool>
+    }
+
+    pub enum EventOrSubtype {    
+        Event(Event),
+        EmploymentEvent(EmploymentEvent),
+        MedicalEvent(MedicalEvent)
+    }
+
+polymorphic traits are implemented:
+
+
+.. code-block:: rust
+
+    pub trait Event   {
+        fn started_at_time(&self) -> Option<&NaiveDate>;
+        fn ended_at_time(&self) -> Option<&NaiveDate>;
+        fn duration(&self) -> Option<&f64>;
+        fn is_current(&self) -> Option<&bool>;
+    }
+
+    pub trait MedicalEvent : Event   {
+        fn in_location(&self) -> Option<&str>;
+        fn diagnosis(&self) -> Option<&crate::DiagnosisConcept>;
+        fn procedure(&self) -> Option<&crate::ProcedureConcept>;
+    }    
+
+    impl Event for crate::MedicalEvent {
+            fn started_at_time(&self) -> Option<&NaiveDate> {
+            return self.started_at_time.as_ref();
+        }
+            fn ended_at_time(&self) -> Option<&NaiveDate> {
+            return self.ended_at_time.as_ref();
+        }
+            fn duration(&self) -> Option<&f64> {
+            return self.duration.as_ref();
+        }
+            fn is_current(&self) -> Option<&bool> {
+            return self.is_current.as_ref();
+        }
+    }
+
+    ...
+
+    impl Event for crate::EventOrSubtype {
+            fn started_at_time(&self) -> Option<&NaiveDate> {
+            match self {
+                    EventOrSubtype::Event(val) => val.started_at_time(),
+                    EventOrSubtype::EmploymentEvent(val) => val.started_at_time(),
+                    EventOrSubtype::MedicalEvent(val) => val.started_at_time(),
+
+            }
+        }
+            fn ended_at_time(&self) -> Option<&NaiveDate> {
+            match self {
+                    EventOrSubtype::Event(val) => val.ended_at_time(),
+                    EventOrSubtype::EmploymentEvent(val) => val.ended_at_time(),
+                    EventOrSubtype::MedicalEvent(val) => val.ended_at_time(),
+
+            }
+        }
+            fn duration(&self) -> Option<&f64> {
+            match self {
+                    EventOrSubtype::Event(val) => val.duration(),
+                    EventOrSubtype::EmploymentEvent(val) => val.duration(),
+                    EventOrSubtype::MedicalEvent(val) => val.duration(),
+
+            }
+        }
+            fn is_current(&self) -> Option<&bool> {
+            match self {
+                    EventOrSubtype::Event(val) => val.is_current(),
+                    EventOrSubtype::EmploymentEvent(val) => val.is_current(),
+                    EventOrSubtype::MedicalEvent(val) => val.is_current(),
+
+            }
+        }
+    }
+
+
 
 
 Command Line
 ------------
 
-.. currentmodule:: linkml.generators.pydanticgen
+.. currentmodule:: linkml.generators.rustgen
 
-.. click:: linkml.generators.pydanticgen:cli
-    :prog: gen-pydantic
+.. click:: linkml.generators.rustgen:cli
+    :prog: gen-rust
     :nested: short
         
 Generator
 ---------
 
         
-.. autoclass:: PydanticGenerator
+.. autoclass:: RustGenerator
     :members:
 
-Split Generation
-----------------
-
-Pydantic models can also be generated in a "split" mode where rather than
-rolling down all classes into a single file, schemas are kept as their own
-pydantic modules that import from one another.
-
-See:
-
-* :attr:`.PydanticGenerator.split`
-* :attr:`.PydanticGenerator.split_pattern`
-* :attr:`.PydanticGenerator.split_context`
-* :meth:`.PydanticGenerator.generate_split`
-
-The implementation of ``split`` mode in the Generator itself still generates
-a single module, except for importing classes from other modules rather than
-including them directly. This is wrapped by :meth:`.PydanticGenerator.generate_split` which
-can be used to generate the module files directly
-
-
-Templates
----------
-
-The pydanticgen module has a templating system that allows each part of a
-schema to be generated independently and customized. See the documentation
-for the individual classes, but in short - each part of the output pydantic
-domain has a model with a corresponding template. At render time, each model
-is recursively rendered.
-
-The :class:`.PydanticGenerator` then serves as a translation layer between
-the source models from :mod:`linkml_runtime` and the target models in
-:mod:`.pydanticgen.template` , making clear what is needed to generate
-pydantic code as well as what parts of the linkml metamodel are supported.
-
-Usage example:
-
-Imports:
-
-.. code-block:: python
-
-    imports = (Imports() +
-        Import(module="sys") +
-        Import(module="pydantic", objects=[{"name": "BaseModel"}, {"name": "Field"}])
-    )
-
-renders to:
-
-.. code-block:: python
-
-    import sys
-    from pydantic import (
-        BaseModel,
-        Field
-    )
-
-Attributes:
-
-.. code-block:: python
-
-    attr = PydanticAttribute(
-        name="my_field",
-        annotations={"python_range": {"value": "str"}},
-        title="My Field!",
-        description="A Field that is mine!",
-        pattern="my_.*",
-    )
-
-By itself, renders to:
-
-.. code-block:: python
-
-    my_field: str = Field(None, title="My Field!", description="""A Field that is mine!""")
-
-Classes:
-
-.. code-block:: python
-
-    cls = PydanticClass(
-        name="MyClass",
-        bases="BaseModel",
-        description="A Class I Made!",
-        attributes={"my_field": attr},
-    )
-
-Renders to (along with the validator for the attribute):
-
-.. code-block:: python
-
-    class MyClass(BaseModel):
-        my_field: str = Field(None, title="My Field!", description="""A Field that is mine!""")
-
-        @validator('my_field', allow_reuse=True)
-        def pattern_my_field(cls, v):
-            pattern=re.compile(r"my_.*")
-            if isinstance(v,list):
-                for element in v:
-                    if not pattern.match(element):
-                        raise ValueError(f"Invalid my_field format: {element}")
-            elif isinstance(v,str):
-                if not pattern.match(v):
-                    raise ValueError(f"Invalid my_field format: {v}")
-            return v
-
-Modules:
-
-.. code-block:: python
-
-    module = PydanticModule(imports=imports, classes={cls.name: cls})
-
-Combine all the pieces:
-
-.. code-block:: python
-
-    import sys
-    from pydantic import (
-        BaseModel,
-        Field
-    )
-
-    metamodel_version = "None"
-    version = "None"
-
-    class WeakRefShimBaseModel(BaseModel):
-        __slots__ = '__weakref__'
-
-
-    class ConfiguredBaseModel(WeakRefShimBaseModel,
-                    validate_assignment = True,
-                    validate_all = True,
-                    underscore_attrs_are_private = True,
-                    extra = "forbid",
-                    arbitrary_types_allowed = True,
-                    use_enum_values = True):
-        pass
-
-
-    class MyClass(BaseModel):
-        my_field: str = Field(None, title="My Field!", description="""A Field that is mine!""")
-
-        @validator('my_field', allow_reuse=True)
-        def pattern_my_field(cls, v):
-            pattern=re.compile(r"my_.*")
-            if isinstance(v,list):
-                for element in v:
-                    if not pattern.match(element):
-                        raise ValueError(f"Invalid my_field format: {element}")
-            elif isinstance(v,str):
-                if not pattern.match(v):
-                    raise ValueError(f"Invalid my_field format: {v}")
-            return v
-
-
-    # Update forward refs
-    # see https://pydantic-docs.helpmanual.io/usage/postponed_annotations/
-    MyClass.update_forward_refs()
-
-
-.. automodule:: linkml.generators.pydanticgen.template
-    :members:
-    :undoc-members:
-    :member-order: bysource
-
-Arrays
--------
-
-.. admonition:: TODO
-
-    Narrative documentation for pydantic LoL Arrays. Subsection this by different array reps
-
-See `Schemas/Arrays <arrays>`_
-
-.. automodule:: linkml.generators.pydanticgen.array
-    :members:
-    :member-order: bysource
-
-Additional Notes
-----------------
-LinkML contains two Python generators. The Pydantic dataclass generator is specifically
-useful for FastAPI, but is newer and less full featured than the standard 
-:doc:`Python generator </generators/python>`.
-
-
-Biolink Example
----------------
-
-Begin by downloading the Biolink Model YAML and adding a virtual environment and installing linkml.
-
-.. code-block:: bash
-
-    curl -OJ https://raw.githubusercontent.com/biolink/biolink-model/master/biolink-model.yaml
-    python3 -m venv venv
-    source venv/bin/activate
-    pip install linkml
-
-Now generate the classes using the `gen-pydantic` command
-
-.. code-block:: bash
-
-    gen-pydantic biolink-model.yaml > biolink-model.py

--- a/docs/generators/rust.rst
+++ b/docs/generators/rust.rst
@@ -1,0 +1,289 @@
+:tocdepth: 3
+
+.. _rustgen:
+
+Rust
+========
+
+Example Output
+--------------
+
+`personinfo_pydantic.py <https://github.com/linkml/linkml/tree/main/examples/PersonSchema/personinfo_pydantic.py>`_
+
+Overview
+--------
+
+The Rust Generator produces a Rust crate with structs and enums from a LinkML model, with optional pyo3 and serde support.
+It additionally generates a trait for every struct to provide polymorphic access, in the `poly.rs` file.
+
+The Pydantic Generator produces Pydantic flavored python dataclasses from a linkml model,
+with optional support for user-supplied jinja2 templates to generate alternate classes.
+
+
+Example
+^^^^^^^
+
+Given a definition of a Person class:
+
+.. code-block:: yaml
+
+     
+    Person:
+      is_a: NamedThing
+      description: >-
+        A person (alive, dead, undead, or fictional).
+      class_uri: schema:Person
+      mixins:
+        - HasAliases
+      slots:
+        - primary_email
+        - birth_date
+        - age_in_years
+        - gender
+        - current_address
+        - has_employment_history
+        - has_familial_relationships
+        - has_medical_history
+
+(some details omitted for brevity, including slot definitions and
+parent classes)
+
+The generate python looks like this:
+
+.. code-block:: python
+
+             
+    class Person(NamedThing):
+        """
+        A person (alive, dead, undead, or fictional).
+        """
+        primary_email: Optional[str] = Field(None)
+        birth_date: Optional[str] = Field(None)
+        age_in_years: Optional[int] = Field(None, ge=0, le=999)
+        gender: Optional[GenderType] = Field(None)
+        current_address: Optional[Address] = Field(None, description="""The address at which a person currently lives""")
+        has_employment_history: Optional[List[EmploymentEvent]] = Field(None)
+        has_familial_relationships: Optional[List[FamilialRelationship]] = Field(None)
+        has_medical_history: Optional[List[MedicalEvent]] = Field(None)
+        aliases: Optional[List[str]] = Field(None)
+        id: Optional[str] = Field(None)
+        name: Optional[str] = Field(None)
+        description: Optional[str] = Field(None)
+        image: Optional[str] = Field(None)
+
+
+Command Line
+------------
+
+.. currentmodule:: linkml.generators.pydanticgen
+
+.. click:: linkml.generators.pydanticgen:cli
+    :prog: gen-pydantic
+    :nested: short
+        
+Generator
+---------
+
+        
+.. autoclass:: PydanticGenerator
+    :members:
+
+Split Generation
+----------------
+
+Pydantic models can also be generated in a "split" mode where rather than
+rolling down all classes into a single file, schemas are kept as their own
+pydantic modules that import from one another.
+
+See:
+
+* :attr:`.PydanticGenerator.split`
+* :attr:`.PydanticGenerator.split_pattern`
+* :attr:`.PydanticGenerator.split_context`
+* :meth:`.PydanticGenerator.generate_split`
+
+The implementation of ``split`` mode in the Generator itself still generates
+a single module, except for importing classes from other modules rather than
+including them directly. This is wrapped by :meth:`.PydanticGenerator.generate_split` which
+can be used to generate the module files directly
+
+
+Templates
+---------
+
+The pydanticgen module has a templating system that allows each part of a
+schema to be generated independently and customized. See the documentation
+for the individual classes, but in short - each part of the output pydantic
+domain has a model with a corresponding template. At render time, each model
+is recursively rendered.
+
+The :class:`.PydanticGenerator` then serves as a translation layer between
+the source models from :mod:`linkml_runtime` and the target models in
+:mod:`.pydanticgen.template` , making clear what is needed to generate
+pydantic code as well as what parts of the linkml metamodel are supported.
+
+Usage example:
+
+Imports:
+
+.. code-block:: python
+
+    imports = (Imports() +
+        Import(module="sys") +
+        Import(module="pydantic", objects=[{"name": "BaseModel"}, {"name": "Field"}])
+    )
+
+renders to:
+
+.. code-block:: python
+
+    import sys
+    from pydantic import (
+        BaseModel,
+        Field
+    )
+
+Attributes:
+
+.. code-block:: python
+
+    attr = PydanticAttribute(
+        name="my_field",
+        annotations={"python_range": {"value": "str"}},
+        title="My Field!",
+        description="A Field that is mine!",
+        pattern="my_.*",
+    )
+
+By itself, renders to:
+
+.. code-block:: python
+
+    my_field: str = Field(None, title="My Field!", description="""A Field that is mine!""")
+
+Classes:
+
+.. code-block:: python
+
+    cls = PydanticClass(
+        name="MyClass",
+        bases="BaseModel",
+        description="A Class I Made!",
+        attributes={"my_field": attr},
+    )
+
+Renders to (along with the validator for the attribute):
+
+.. code-block:: python
+
+    class MyClass(BaseModel):
+        my_field: str = Field(None, title="My Field!", description="""A Field that is mine!""")
+
+        @validator('my_field', allow_reuse=True)
+        def pattern_my_field(cls, v):
+            pattern=re.compile(r"my_.*")
+            if isinstance(v,list):
+                for element in v:
+                    if not pattern.match(element):
+                        raise ValueError(f"Invalid my_field format: {element}")
+            elif isinstance(v,str):
+                if not pattern.match(v):
+                    raise ValueError(f"Invalid my_field format: {v}")
+            return v
+
+Modules:
+
+.. code-block:: python
+
+    module = PydanticModule(imports=imports, classes={cls.name: cls})
+
+Combine all the pieces:
+
+.. code-block:: python
+
+    import sys
+    from pydantic import (
+        BaseModel,
+        Field
+    )
+
+    metamodel_version = "None"
+    version = "None"
+
+    class WeakRefShimBaseModel(BaseModel):
+        __slots__ = '__weakref__'
+
+
+    class ConfiguredBaseModel(WeakRefShimBaseModel,
+                    validate_assignment = True,
+                    validate_all = True,
+                    underscore_attrs_are_private = True,
+                    extra = "forbid",
+                    arbitrary_types_allowed = True,
+                    use_enum_values = True):
+        pass
+
+
+    class MyClass(BaseModel):
+        my_field: str = Field(None, title="My Field!", description="""A Field that is mine!""")
+
+        @validator('my_field', allow_reuse=True)
+        def pattern_my_field(cls, v):
+            pattern=re.compile(r"my_.*")
+            if isinstance(v,list):
+                for element in v:
+                    if not pattern.match(element):
+                        raise ValueError(f"Invalid my_field format: {element}")
+            elif isinstance(v,str):
+                if not pattern.match(v):
+                    raise ValueError(f"Invalid my_field format: {v}")
+            return v
+
+
+    # Update forward refs
+    # see https://pydantic-docs.helpmanual.io/usage/postponed_annotations/
+    MyClass.update_forward_refs()
+
+
+.. automodule:: linkml.generators.pydanticgen.template
+    :members:
+    :undoc-members:
+    :member-order: bysource
+
+Arrays
+-------
+
+.. admonition:: TODO
+
+    Narrative documentation for pydantic LoL Arrays. Subsection this by different array reps
+
+See `Schemas/Arrays <arrays>`_
+
+.. automodule:: linkml.generators.pydanticgen.array
+    :members:
+    :member-order: bysource
+
+Additional Notes
+----------------
+LinkML contains two Python generators. The Pydantic dataclass generator is specifically
+useful for FastAPI, but is newer and less full featured than the standard 
+:doc:`Python generator </generators/python>`.
+
+
+Biolink Example
+---------------
+
+Begin by downloading the Biolink Model YAML and adding a virtual environment and installing linkml.
+
+.. code-block:: bash
+
+    curl -OJ https://raw.githubusercontent.com/biolink/biolink-model/master/biolink-model.yaml
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install linkml
+
+Now generate the classes using the `gen-pydantic` command
+
+.. code-block:: bash
+
+    gen-pydantic biolink-model.yaml > biolink-model.py

--- a/examples/PersonSchema/rust/Cargo.toml
+++ b/examples/PersonSchema/rust/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "personinfo"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+name = "personinfo"
+crate-type = ["lib"]
+
+[dependencies]
+pyo3 = { version = "0.25.0", features = ["chrono"]  , optional = true  }
+serde = { version = "1.0", features = ["derive"]  , optional = true  }
+serde-value = "0.7.0"
+serde_yml = { version = "0.0.12", optional = true }
+serde_path_to_error = { version = "0.1.17", optional = true }
+chrono = { version = "0.4.41", features = ["serde"]  }
+
+
+[features]
+default = []
+pyo3 = ["dep:pyo3"]
+serde = ["dep:serde", "dep:serde_yml", "dep:serde_path_to_error"]

--- a/examples/PersonSchema/rust/pyproject.toml
+++ b/examples/PersonSchema/rust/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "personinfo"
+version = "0.0.0"
+
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[tool.maturin]
+features = ["pyo3/extension-module"]

--- a/examples/PersonSchema/rust/src/lib.rs
+++ b/examples/PersonSchema/rust/src/lib.rs
@@ -180,7 +180,7 @@ impl serde_utils::InlinedPair for NamedThing {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[serde(untagged)]
+#[cfg_attr(feature="serde", serde(untagged))]
 pub enum NamedThingOrSubtype {    NamedThing(NamedThing),     Person(Person),     Organization(Organization),     Concept(Concept),     DiagnosisConcept(DiagnosisConcept),     ProcedureConcept(ProcedureConcept)}
 
 impl From<NamedThing>   for NamedThingOrSubtype { fn from(x: NamedThing)   -> Self { Self::NamedThing(x) } }
@@ -456,7 +456,7 @@ impl<'py> FromPyObject<'py> for Box<HasAliases> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[serde(untagged)]
+#[cfg_attr(feature="serde", serde(untagged))]
 pub enum HasAliasesOrSubtype {    HasAliases(HasAliases),     Person(Person),     Organization(Organization),     Place(Place)}
 
 impl From<HasAliases>   for HasAliasesOrSubtype { fn from(x: HasAliases)   -> Self { Self::HasAliases(x) } }
@@ -782,7 +782,7 @@ impl<'py> FromPyObject<'py> for Box<Event> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[serde(untagged)]
+#[cfg_attr(feature="serde", serde(untagged))]
 pub enum EventOrSubtype {    Event(Event),     EmploymentEvent(EmploymentEvent),     MedicalEvent(MedicalEvent)}
 
 impl From<Event>   for EventOrSubtype { fn from(x: Event)   -> Self { Self::Event(x) } }
@@ -928,7 +928,7 @@ impl serde_utils::InlinedPair for Concept {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[serde(untagged)]
+#[cfg_attr(feature="serde", serde(untagged))]
 pub enum ConceptOrSubtype {    Concept(Concept),     DiagnosisConcept(DiagnosisConcept),     ProcedureConcept(ProcedureConcept)}
 
 impl From<Concept>   for ConceptOrSubtype { fn from(x: Concept)   -> Self { Self::Concept(x) } }
@@ -1241,7 +1241,7 @@ impl<'py> FromPyObject<'py> for Box<Relationship> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[serde(untagged)]
+#[cfg_attr(feature="serde", serde(untagged))]
 pub enum RelationshipOrSubtype {    Relationship(Relationship),     FamilialRelationship(FamilialRelationship)}
 
 impl From<Relationship>   for RelationshipOrSubtype { fn from(x: Relationship)   -> Self { Self::Relationship(x) } }

--- a/examples/PersonSchema/rust/src/lib.rs
+++ b/examples/PersonSchema/rust/src/lib.rs
@@ -1,0 +1,1527 @@
+#![allow(non_camel_case_types)]
+
+#[cfg(feature = "serde")]
+mod serde_utils;
+pub mod poly;
+pub mod poly_containers;
+
+#[cfg(feature = "serde")]
+use serde_yml as _ ;
+use chrono::NaiveDate;
+#[cfg(feature = "pyo3")]
+use pyo3::{FromPyObject,prelude::*};
+#[cfg(feature = "serde")]
+use serde::{Deserialize,Serialize,de::IntoDeserializer};
+use serde_value::Value;
+#[cfg(feature = "serde")]
+use serde_path_to_error;
+use std::collections::HashMap;
+use std::collections::BTreeMap;
+
+// Types
+
+pub type string = String;
+pub type integer = String;
+pub type boolean = String;
+pub type float = f64;
+pub type double = f64;
+pub type decimal = String;
+pub type time = String;
+pub type date = String;
+pub type datetime = String;
+pub type date_or_datetime = String;
+pub type uriorcurie = String;
+pub type curie = String;
+pub type uri = String;
+pub type ncname = String;
+pub type objectidentifier = String;
+pub type nodeidentifier = String;
+pub type jsonpointer = String;
+pub type jsonpath = String;
+pub type sparqlpath = String;
+
+// Slots
+
+pub type id = String;
+pub type name = String;
+pub type description = String;
+pub type image = String;
+pub type gender = String;
+pub type primary_email = String;
+pub type birth_date = String;
+pub type employed_at = Organization;
+pub type is_current = bool;
+pub type has_employment_history = Vec<EmploymentEvent>;
+pub type has_medical_history = Vec<MedicalEvent>;
+pub type has_familial_relationships = Vec<FamilialRelationship>;
+pub type in_location = Place;
+pub type current_address = Address;
+pub type age_in_years = isize;
+pub type related_to = String;
+pub type type_ = String;
+pub type street = String;
+pub type city = String;
+pub type mission_statement = String;
+pub type founding_date = String;
+pub type founding_location = Place;
+pub type postal_code = String;
+pub type started_at_time = NaiveDate;
+pub type duration = f64;
+pub type diagnosis = DiagnosisConcept;
+pub type procedure = ProcedureConcept;
+pub type ended_at_time = NaiveDate;
+pub type persons = Vec<Person>;
+pub type organizations = Vec<Organization>;
+pub type aliases = Vec<String>;
+
+// Enums
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum FamilialRelationshipType {
+    SIBLINGOF,
+    PARENTOF,
+    CHILDOF,
+}
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum GenderType {
+    NonbinaryMan,
+    NonbinaryWoman,
+    TransgenderWoman,
+    TransgenderMan,
+    CisgenderMan,
+    CisgenderWoman,
+}
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum DiagnosisType {
+}
+
+// Classes
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+pub struct NamedThing {
+    pub id: String,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub name: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub description: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub image: Option<String>
+}
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl NamedThing {
+    #[new]
+    pub fn new(id: String, name: Option<String>, description: Option<String>, image: Option<String>) -> Self {
+        NamedThing{id, name, description, image}
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<NamedThing>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<NamedThing> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<NamedThing>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid NamedThing",
+        ))
+    }
+}
+#[cfg(feature = "serde")]
+impl serde_utils::InlinedPair for NamedThing {
+    type Key   = String;
+        
+    type Value = String;
+    type Error = String;
+
+    fn extract_key(&self) -> &Self::Key {
+        return &self.id;
+    }
+
+    fn from_pair_mapping(k: Self::Key, v: Value) -> Result<Self,Self::Error> {
+        let mut map = match v {
+            Value::Map(m) => m,
+            _ => return Err("ClassDefinition must be a mapping".into()),
+        };
+        map.insert(Value::String("id".into()), Value::String(k));
+        let de          = Value::Map(map).into_deserializer();
+        match serde_path_to_error::deserialize(de) {
+            Ok(ok)  => Ok(ok),
+            Err(e)  => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+
+        
+    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self,Self::Error> {
+        let mut map:  BTreeMap<Value, Value> = BTreeMap::new();
+        map.insert(Value::String("id".into()), Value::String(k));
+        map.insert(Value::String("name".into()), v);
+        let de          = Value::Map(map).into_deserializer();
+        match serde_path_to_error::deserialize(de) {
+            Ok(ok)  => Ok(ok),
+            Err(e)  => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }        
+
+    }
+}
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[serde(untagged)]
+pub enum NamedThingOrSubtype {    NamedThing(NamedThing),     Person(Person),     Organization(Organization),     Concept(Concept),     DiagnosisConcept(DiagnosisConcept),     ProcedureConcept(ProcedureConcept)}
+
+impl From<NamedThing>   for NamedThingOrSubtype { fn from(x: NamedThing)   -> Self { Self::NamedThing(x) } }
+impl From<Person>   for NamedThingOrSubtype { fn from(x: Person)   -> Self { Self::Person(x) } }
+impl From<Organization>   for NamedThingOrSubtype { fn from(x: Organization)   -> Self { Self::Organization(x) } }
+impl From<Concept>   for NamedThingOrSubtype { fn from(x: Concept)   -> Self { Self::Concept(x) } }
+impl From<DiagnosisConcept>   for NamedThingOrSubtype { fn from(x: DiagnosisConcept)   -> Self { Self::DiagnosisConcept(x) } }
+impl From<ProcedureConcept>   for NamedThingOrSubtype { fn from(x: ProcedureConcept)   -> Self { Self::ProcedureConcept(x) } }
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for NamedThingOrSubtype {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<NamedThing>() {
+            return Ok(NamedThingOrSubtype::NamedThing(val));
+        }        if let Ok(val) = ob.extract::<Person>() {
+            return Ok(NamedThingOrSubtype::Person(val));
+        }        if let Ok(val) = ob.extract::<Organization>() {
+            return Ok(NamedThingOrSubtype::Organization(val));
+        }        if let Ok(val) = ob.extract::<Concept>() {
+            return Ok(NamedThingOrSubtype::Concept(val));
+        }        if let Ok(val) = ob.extract::<DiagnosisConcept>() {
+            return Ok(NamedThingOrSubtype::DiagnosisConcept(val));
+        }        if let Ok(val) = ob.extract::<ProcedureConcept>() {
+            return Ok(NamedThingOrSubtype::ProcedureConcept(val));
+        }Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid NamedThingOrSubtype",
+        ))
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for NamedThingOrSubtype {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        match self {
+            NamedThingOrSubtype::NamedThing(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+            NamedThingOrSubtype::Person(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+            NamedThingOrSubtype::Organization(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+            NamedThingOrSubtype::Concept(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+            NamedThingOrSubtype::DiagnosisConcept(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+            NamedThingOrSubtype::ProcedureConcept(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+        }
+    }
+}
+
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<NamedThingOrSubtype>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<NamedThingOrSubtype> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<NamedThingOrSubtype>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid NamedThingOrSubtype",
+        ))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_utils::InlinedPair for NamedThingOrSubtype {
+    type Key       = String;
+    type Value     = serde_value::Value;
+    type Error     = String;
+
+    fn from_pair_mapping(k: Self::Key, v: Self::Value) -> Result<Self, Self::Error> {
+        if let Ok(x) = NamedThing::from_pair_mapping(k.clone(), v.clone()) {
+            return Ok(NamedThingOrSubtype::NamedThing(x));
+        }
+        if let Ok(x) = Person::from_pair_mapping(k.clone(), v.clone()) {
+            return Ok(NamedThingOrSubtype::Person(x));
+        }
+        if let Ok(x) = Organization::from_pair_mapping(k.clone(), v.clone()) {
+            return Ok(NamedThingOrSubtype::Organization(x));
+        }
+        if let Ok(x) = Concept::from_pair_mapping(k.clone(), v.clone()) {
+            return Ok(NamedThingOrSubtype::Concept(x));
+        }
+        if let Ok(x) = DiagnosisConcept::from_pair_mapping(k.clone(), v.clone()) {
+            return Ok(NamedThingOrSubtype::DiagnosisConcept(x));
+        }
+        if let Ok(x) = ProcedureConcept::from_pair_mapping(k.clone(), v.clone()) {
+            return Ok(NamedThingOrSubtype::ProcedureConcept(x));
+        }
+        Err("none of the variants matched the mapping form".into())
+    }
+
+    fn from_pair_simple(k: Self::Key, v: Self::Value) -> Result<Self, Self::Error> {
+        if let Ok(x) = NamedThing::from_pair_simple(k.clone(), v.clone()) {
+            return Ok(NamedThingOrSubtype::NamedThing(x));
+        }
+        if let Ok(x) = Person::from_pair_simple(k.clone(), v.clone()) {
+            return Ok(NamedThingOrSubtype::Person(x));
+        }
+        if let Ok(x) = Organization::from_pair_simple(k.clone(), v.clone()) {
+            return Ok(NamedThingOrSubtype::Organization(x));
+        }
+        if let Ok(x) = Concept::from_pair_simple(k.clone(), v.clone()) {
+            return Ok(NamedThingOrSubtype::Concept(x));
+        }
+        if let Ok(x) = DiagnosisConcept::from_pair_simple(k.clone(), v.clone()) {
+            return Ok(NamedThingOrSubtype::DiagnosisConcept(x));
+        }
+        if let Ok(x) = ProcedureConcept::from_pair_simple(k.clone(), v.clone()) {
+            return Ok(NamedThingOrSubtype::ProcedureConcept(x));
+        }
+        Err("none of the variants support the primitive form".into())
+    }
+
+    fn extract_key(&self) -> &Self::Key {
+        match self {
+            NamedThingOrSubtype::NamedThing(inner) => inner.extract_key(),
+            NamedThingOrSubtype::Person(inner) => inner.extract_key(),
+            NamedThingOrSubtype::Organization(inner) => inner.extract_key(),
+            NamedThingOrSubtype::Concept(inner) => inner.extract_key(),
+            NamedThingOrSubtype::DiagnosisConcept(inner) => inner.extract_key(),
+            NamedThingOrSubtype::ProcedureConcept(inner) => inner.extract_key(),
+        }
+    }
+}
+
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+pub struct Person {
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub primary_email: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub birth_date: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub age_in_years: Option<isize>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub gender: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub current_address: Option<Address>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub has_employment_history: Vec<EmploymentEvent>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub has_familial_relationships: Vec<Box<FamilialRelationship>>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub has_medical_history: Vec<MedicalEvent>,
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value"))]#[cfg_attr(feature = "serde", serde(default))]
+    pub aliases: Vec<String>,
+    pub id: String,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub name: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub description: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub image: Option<String>
+}
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl Person {
+    #[new]
+    pub fn new(primary_email: Option<String>, birth_date: Option<String>, age_in_years: Option<isize>, gender: Option<String>, current_address: Option<Address>, has_employment_history: Vec<EmploymentEvent>, has_familial_relationships: Vec<Box<FamilialRelationship>>, has_medical_history: Vec<MedicalEvent>, aliases: Vec<String>, id: String, name: Option<String>, description: Option<String>, image: Option<String>) -> Self {
+        Person{primary_email, birth_date, age_in_years, gender, current_address, has_employment_history, has_familial_relationships, has_medical_history, aliases, id, name, description, image}
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<Person>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<Person> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<Person>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid Person",
+        ))
+    }
+}
+#[cfg(feature = "serde")]
+impl serde_utils::InlinedPair for Person {
+    type Key   = String;
+        
+    type Value = String;
+    type Error = String;
+
+    fn extract_key(&self) -> &Self::Key {
+        return &self.id;
+    }
+
+    fn from_pair_mapping(k: Self::Key, v: Value) -> Result<Self,Self::Error> {
+        let mut map = match v {
+            Value::Map(m) => m,
+            _ => return Err("ClassDefinition must be a mapping".into()),
+        };
+        map.insert(Value::String("id".into()), Value::String(k));
+        let de          = Value::Map(map).into_deserializer();
+        match serde_path_to_error::deserialize(de) {
+            Ok(ok)  => Ok(ok),
+            Err(e)  => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+
+        
+    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self,Self::Error> {
+        let mut map:  BTreeMap<Value, Value> = BTreeMap::new();
+        map.insert(Value::String("id".into()), Value::String(k));
+        map.insert(Value::String("primary_email".into()), v);
+        let de          = Value::Map(map).into_deserializer();
+        match serde_path_to_error::deserialize(de) {
+            Ok(ok)  => Ok(ok),
+            Err(e)  => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }        
+
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+pub struct HasAliases {
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value"))]#[cfg_attr(feature = "serde", serde(default))]
+    pub aliases: Vec<String>
+}
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl HasAliases {
+    #[new]
+    pub fn new(aliases: Vec<String>) -> Self {
+        HasAliases{aliases}
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<HasAliases>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<HasAliases> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<HasAliases>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid HasAliases",
+        ))
+    }
+}
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[serde(untagged)]
+pub enum HasAliasesOrSubtype {    HasAliases(HasAliases),     Person(Person),     Organization(Organization),     Place(Place)}
+
+impl From<HasAliases>   for HasAliasesOrSubtype { fn from(x: HasAliases)   -> Self { Self::HasAliases(x) } }
+impl From<Person>   for HasAliasesOrSubtype { fn from(x: Person)   -> Self { Self::Person(x) } }
+impl From<Organization>   for HasAliasesOrSubtype { fn from(x: Organization)   -> Self { Self::Organization(x) } }
+impl From<Place>   for HasAliasesOrSubtype { fn from(x: Place)   -> Self { Self::Place(x) } }
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for HasAliasesOrSubtype {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<HasAliases>() {
+            return Ok(HasAliasesOrSubtype::HasAliases(val));
+        }        if let Ok(val) = ob.extract::<Person>() {
+            return Ok(HasAliasesOrSubtype::Person(val));
+        }        if let Ok(val) = ob.extract::<Organization>() {
+            return Ok(HasAliasesOrSubtype::Organization(val));
+        }        if let Ok(val) = ob.extract::<Place>() {
+            return Ok(HasAliasesOrSubtype::Place(val));
+        }Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid HasAliasesOrSubtype",
+        ))
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for HasAliasesOrSubtype {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        match self {
+            HasAliasesOrSubtype::HasAliases(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+            HasAliasesOrSubtype::Person(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+            HasAliasesOrSubtype::Organization(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+            HasAliasesOrSubtype::Place(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+        }
+    }
+}
+
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<HasAliasesOrSubtype>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<HasAliasesOrSubtype> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<HasAliasesOrSubtype>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid HasAliasesOrSubtype",
+        ))
+    }
+}
+
+
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+pub struct Organization {
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub mission_statement: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub founding_date: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub founding_location: Option<String>,
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value"))]#[cfg_attr(feature = "serde", serde(default))]
+    pub aliases: Vec<String>,
+    pub id: String,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub name: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub description: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub image: Option<String>
+}
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl Organization {
+    #[new]
+    pub fn new(mission_statement: Option<String>, founding_date: Option<String>, founding_location: Option<String>, aliases: Vec<String>, id: String, name: Option<String>, description: Option<String>, image: Option<String>) -> Self {
+        Organization{mission_statement, founding_date, founding_location, aliases, id, name, description, image}
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<Organization>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<Organization> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<Organization>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid Organization",
+        ))
+    }
+}
+#[cfg(feature = "serde")]
+impl serde_utils::InlinedPair for Organization {
+    type Key   = String;
+        
+    type Value = String;
+    type Error = String;
+
+    fn extract_key(&self) -> &Self::Key {
+        return &self.id;
+    }
+
+    fn from_pair_mapping(k: Self::Key, v: Value) -> Result<Self,Self::Error> {
+        let mut map = match v {
+            Value::Map(m) => m,
+            _ => return Err("ClassDefinition must be a mapping".into()),
+        };
+        map.insert(Value::String("id".into()), Value::String(k));
+        let de          = Value::Map(map).into_deserializer();
+        match serde_path_to_error::deserialize(de) {
+            Ok(ok)  => Ok(ok),
+            Err(e)  => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+
+        
+    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self,Self::Error> {
+        let mut map:  BTreeMap<Value, Value> = BTreeMap::new();
+        map.insert(Value::String("id".into()), Value::String(k));
+        map.insert(Value::String("mission_statement".into()), v);
+        let de          = Value::Map(map).into_deserializer();
+        match serde_path_to_error::deserialize(de) {
+            Ok(ok)  => Ok(ok),
+            Err(e)  => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }        
+
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+pub struct Place {
+    pub id: String,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub name: Option<String>,
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value"))]#[cfg_attr(feature = "serde", serde(default))]
+    pub aliases: Vec<String>
+}
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl Place {
+    #[new]
+    pub fn new(id: String, name: Option<String>, aliases: Vec<String>) -> Self {
+        Place{id, name, aliases}
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<Place>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<Place> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<Place>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid Place",
+        ))
+    }
+}
+#[cfg(feature = "serde")]
+impl serde_utils::InlinedPair for Place {
+    type Key   = String;
+        
+    type Value = String;
+    type Error = String;
+
+    fn extract_key(&self) -> &Self::Key {
+        return &self.id;
+    }
+
+    fn from_pair_mapping(k: Self::Key, v: Value) -> Result<Self,Self::Error> {
+        let mut map = match v {
+            Value::Map(m) => m,
+            _ => return Err("ClassDefinition must be a mapping".into()),
+        };
+        map.insert(Value::String("id".into()), Value::String(k));
+        let de          = Value::Map(map).into_deserializer();
+        match serde_path_to_error::deserialize(de) {
+            Ok(ok)  => Ok(ok),
+            Err(e)  => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+
+        
+    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self,Self::Error> {
+        let mut map:  BTreeMap<Value, Value> = BTreeMap::new();
+        map.insert(Value::String("id".into()), Value::String(k));
+        map.insert(Value::String("name".into()), v);
+        let de          = Value::Map(map).into_deserializer();
+        match serde_path_to_error::deserialize(de) {
+            Ok(ok)  => Ok(ok),
+            Err(e)  => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }        
+
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+pub struct Address {
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub street: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub city: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub postal_code: Option<String>
+}
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl Address {
+    #[new]
+    pub fn new(street: Option<String>, city: Option<String>, postal_code: Option<String>) -> Self {
+        Address{street, city, postal_code}
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<Address>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<Address> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<Address>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid Address",
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+pub struct Event {
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub started_at_time: Option<NaiveDate>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub ended_at_time: Option<NaiveDate>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub duration: Option<f64>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub is_current: Option<bool>
+}
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl Event {
+    #[new]
+    pub fn new(started_at_time: Option<NaiveDate>, ended_at_time: Option<NaiveDate>, duration: Option<f64>, is_current: Option<bool>) -> Self {
+        Event{started_at_time, ended_at_time, duration, is_current}
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<Event>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<Event> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<Event>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid Event",
+        ))
+    }
+}
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[serde(untagged)]
+pub enum EventOrSubtype {    Event(Event),     EmploymentEvent(EmploymentEvent),     MedicalEvent(MedicalEvent)}
+
+impl From<Event>   for EventOrSubtype { fn from(x: Event)   -> Self { Self::Event(x) } }
+impl From<EmploymentEvent>   for EventOrSubtype { fn from(x: EmploymentEvent)   -> Self { Self::EmploymentEvent(x) } }
+impl From<MedicalEvent>   for EventOrSubtype { fn from(x: MedicalEvent)   -> Self { Self::MedicalEvent(x) } }
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for EventOrSubtype {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<Event>() {
+            return Ok(EventOrSubtype::Event(val));
+        }        if let Ok(val) = ob.extract::<EmploymentEvent>() {
+            return Ok(EventOrSubtype::EmploymentEvent(val));
+        }        if let Ok(val) = ob.extract::<MedicalEvent>() {
+            return Ok(EventOrSubtype::MedicalEvent(val));
+        }Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid EventOrSubtype",
+        ))
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for EventOrSubtype {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        match self {
+            EventOrSubtype::Event(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+            EventOrSubtype::EmploymentEvent(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+            EventOrSubtype::MedicalEvent(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+        }
+    }
+}
+
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<EventOrSubtype>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<EventOrSubtype> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<EventOrSubtype>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid EventOrSubtype",
+        ))
+    }
+}
+
+
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+pub struct Concept {
+    pub id: String,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub name: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub description: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub image: Option<String>
+}
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl Concept {
+    #[new]
+    pub fn new(id: String, name: Option<String>, description: Option<String>, image: Option<String>) -> Self {
+        Concept{id, name, description, image}
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<Concept>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<Concept> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<Concept>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid Concept",
+        ))
+    }
+}
+#[cfg(feature = "serde")]
+impl serde_utils::InlinedPair for Concept {
+    type Key   = String;
+        
+    type Value = String;
+    type Error = String;
+
+    fn extract_key(&self) -> &Self::Key {
+        return &self.id;
+    }
+
+    fn from_pair_mapping(k: Self::Key, v: Value) -> Result<Self,Self::Error> {
+        let mut map = match v {
+            Value::Map(m) => m,
+            _ => return Err("ClassDefinition must be a mapping".into()),
+        };
+        map.insert(Value::String("id".into()), Value::String(k));
+        let de          = Value::Map(map).into_deserializer();
+        match serde_path_to_error::deserialize(de) {
+            Ok(ok)  => Ok(ok),
+            Err(e)  => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+
+        
+    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self,Self::Error> {
+        let mut map:  BTreeMap<Value, Value> = BTreeMap::new();
+        map.insert(Value::String("id".into()), Value::String(k));
+        map.insert(Value::String("name".into()), v);
+        let de          = Value::Map(map).into_deserializer();
+        match serde_path_to_error::deserialize(de) {
+            Ok(ok)  => Ok(ok),
+            Err(e)  => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }        
+
+    }
+}
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[serde(untagged)]
+pub enum ConceptOrSubtype {    Concept(Concept),     DiagnosisConcept(DiagnosisConcept),     ProcedureConcept(ProcedureConcept)}
+
+impl From<Concept>   for ConceptOrSubtype { fn from(x: Concept)   -> Self { Self::Concept(x) } }
+impl From<DiagnosisConcept>   for ConceptOrSubtype { fn from(x: DiagnosisConcept)   -> Self { Self::DiagnosisConcept(x) } }
+impl From<ProcedureConcept>   for ConceptOrSubtype { fn from(x: ProcedureConcept)   -> Self { Self::ProcedureConcept(x) } }
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for ConceptOrSubtype {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<Concept>() {
+            return Ok(ConceptOrSubtype::Concept(val));
+        }        if let Ok(val) = ob.extract::<DiagnosisConcept>() {
+            return Ok(ConceptOrSubtype::DiagnosisConcept(val));
+        }        if let Ok(val) = ob.extract::<ProcedureConcept>() {
+            return Ok(ConceptOrSubtype::ProcedureConcept(val));
+        }Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid ConceptOrSubtype",
+        ))
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for ConceptOrSubtype {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        match self {
+            ConceptOrSubtype::Concept(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+            ConceptOrSubtype::DiagnosisConcept(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+            ConceptOrSubtype::ProcedureConcept(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+        }
+    }
+}
+
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<ConceptOrSubtype>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<ConceptOrSubtype> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<ConceptOrSubtype>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid ConceptOrSubtype",
+        ))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_utils::InlinedPair for ConceptOrSubtype {
+    type Key       = String;
+    type Value     = serde_value::Value;
+    type Error     = String;
+
+    fn from_pair_mapping(k: Self::Key, v: Self::Value) -> Result<Self, Self::Error> {
+        if let Ok(x) = Concept::from_pair_mapping(k.clone(), v.clone()) {
+            return Ok(ConceptOrSubtype::Concept(x));
+        }
+        if let Ok(x) = DiagnosisConcept::from_pair_mapping(k.clone(), v.clone()) {
+            return Ok(ConceptOrSubtype::DiagnosisConcept(x));
+        }
+        if let Ok(x) = ProcedureConcept::from_pair_mapping(k.clone(), v.clone()) {
+            return Ok(ConceptOrSubtype::ProcedureConcept(x));
+        }
+        Err("none of the variants matched the mapping form".into())
+    }
+
+    fn from_pair_simple(k: Self::Key, v: Self::Value) -> Result<Self, Self::Error> {
+        if let Ok(x) = Concept::from_pair_simple(k.clone(), v.clone()) {
+            return Ok(ConceptOrSubtype::Concept(x));
+        }
+        if let Ok(x) = DiagnosisConcept::from_pair_simple(k.clone(), v.clone()) {
+            return Ok(ConceptOrSubtype::DiagnosisConcept(x));
+        }
+        if let Ok(x) = ProcedureConcept::from_pair_simple(k.clone(), v.clone()) {
+            return Ok(ConceptOrSubtype::ProcedureConcept(x));
+        }
+        Err("none of the variants support the primitive form".into())
+    }
+
+    fn extract_key(&self) -> &Self::Key {
+        match self {
+            ConceptOrSubtype::Concept(inner) => inner.extract_key(),
+            ConceptOrSubtype::DiagnosisConcept(inner) => inner.extract_key(),
+            ConceptOrSubtype::ProcedureConcept(inner) => inner.extract_key(),
+        }
+    }
+}
+
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+pub struct DiagnosisConcept {
+    pub id: String,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub name: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub description: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub image: Option<String>
+}
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl DiagnosisConcept {
+    #[new]
+    pub fn new(id: String, name: Option<String>, description: Option<String>, image: Option<String>) -> Self {
+        DiagnosisConcept{id, name, description, image}
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<DiagnosisConcept>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<DiagnosisConcept> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<DiagnosisConcept>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid DiagnosisConcept",
+        ))
+    }
+}
+#[cfg(feature = "serde")]
+impl serde_utils::InlinedPair for DiagnosisConcept {
+    type Key   = String;
+        
+    type Value = String;
+    type Error = String;
+
+    fn extract_key(&self) -> &Self::Key {
+        return &self.id;
+    }
+
+    fn from_pair_mapping(k: Self::Key, v: Value) -> Result<Self,Self::Error> {
+        let mut map = match v {
+            Value::Map(m) => m,
+            _ => return Err("ClassDefinition must be a mapping".into()),
+        };
+        map.insert(Value::String("id".into()), Value::String(k));
+        let de          = Value::Map(map).into_deserializer();
+        match serde_path_to_error::deserialize(de) {
+            Ok(ok)  => Ok(ok),
+            Err(e)  => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+
+        
+    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self,Self::Error> {
+        let mut map:  BTreeMap<Value, Value> = BTreeMap::new();
+        map.insert(Value::String("id".into()), Value::String(k));
+        map.insert(Value::String("name".into()), v);
+        let de          = Value::Map(map).into_deserializer();
+        match serde_path_to_error::deserialize(de) {
+            Ok(ok)  => Ok(ok),
+            Err(e)  => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }        
+
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+pub struct ProcedureConcept {
+    pub id: String,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub name: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub description: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub image: Option<String>
+}
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl ProcedureConcept {
+    #[new]
+    pub fn new(id: String, name: Option<String>, description: Option<String>, image: Option<String>) -> Self {
+        ProcedureConcept{id, name, description, image}
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<ProcedureConcept>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<ProcedureConcept> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<ProcedureConcept>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid ProcedureConcept",
+        ))
+    }
+}
+#[cfg(feature = "serde")]
+impl serde_utils::InlinedPair for ProcedureConcept {
+    type Key   = String;
+        
+    type Value = String;
+    type Error = String;
+
+    fn extract_key(&self) -> &Self::Key {
+        return &self.id;
+    }
+
+    fn from_pair_mapping(k: Self::Key, v: Value) -> Result<Self,Self::Error> {
+        let mut map = match v {
+            Value::Map(m) => m,
+            _ => return Err("ClassDefinition must be a mapping".into()),
+        };
+        map.insert(Value::String("id".into()), Value::String(k));
+        let de          = Value::Map(map).into_deserializer();
+        match serde_path_to_error::deserialize(de) {
+            Ok(ok)  => Ok(ok),
+            Err(e)  => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+
+        
+    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self,Self::Error> {
+        let mut map:  BTreeMap<Value, Value> = BTreeMap::new();
+        map.insert(Value::String("id".into()), Value::String(k));
+        map.insert(Value::String("name".into()), v);
+        let de          = Value::Map(map).into_deserializer();
+        match serde_path_to_error::deserialize(de) {
+            Ok(ok)  => Ok(ok),
+            Err(e)  => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }        
+
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+pub struct Relationship {
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub started_at_time: Option<NaiveDate>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub ended_at_time: Option<NaiveDate>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub related_to: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub type_: Option<String>
+}
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl Relationship {
+    #[new]
+    pub fn new(started_at_time: Option<NaiveDate>, ended_at_time: Option<NaiveDate>, related_to: Option<String>, type_: Option<String>) -> Self {
+        Relationship{started_at_time, ended_at_time, related_to, type_}
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<Relationship>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<Relationship> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<Relationship>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid Relationship",
+        ))
+    }
+}
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[serde(untagged)]
+pub enum RelationshipOrSubtype {    Relationship(Relationship),     FamilialRelationship(FamilialRelationship)}
+
+impl From<Relationship>   for RelationshipOrSubtype { fn from(x: Relationship)   -> Self { Self::Relationship(x) } }
+impl From<FamilialRelationship>   for RelationshipOrSubtype { fn from(x: FamilialRelationship)   -> Self { Self::FamilialRelationship(x) } }
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for RelationshipOrSubtype {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<Relationship>() {
+            return Ok(RelationshipOrSubtype::Relationship(val));
+        }        if let Ok(val) = ob.extract::<FamilialRelationship>() {
+            return Ok(RelationshipOrSubtype::FamilialRelationship(val));
+        }Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid RelationshipOrSubtype",
+        ))
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for RelationshipOrSubtype {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        match self {
+            RelationshipOrSubtype::Relationship(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+            RelationshipOrSubtype::FamilialRelationship(val) => val.into_pyobject(py).map(move |b| b.into_any()),
+        }
+    }
+}
+
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<RelationshipOrSubtype>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<RelationshipOrSubtype> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<RelationshipOrSubtype>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid RelationshipOrSubtype",
+        ))
+    }
+}
+
+
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+pub struct FamilialRelationship {
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub started_at_time: Option<NaiveDate>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub ended_at_time: Option<NaiveDate>,
+    pub related_to: String,
+    pub type_: String
+}
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl FamilialRelationship {
+    #[new]
+    pub fn new(started_at_time: Option<NaiveDate>, ended_at_time: Option<NaiveDate>, related_to: String, type_: String) -> Self {
+        FamilialRelationship{started_at_time, ended_at_time, related_to, type_}
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<FamilialRelationship>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<FamilialRelationship> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<FamilialRelationship>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid FamilialRelationship",
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+pub struct EmploymentEvent {
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub employed_at: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub started_at_time: Option<NaiveDate>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub ended_at_time: Option<NaiveDate>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub duration: Option<f64>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub is_current: Option<bool>
+}
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl EmploymentEvent {
+    #[new]
+    pub fn new(employed_at: Option<String>, started_at_time: Option<NaiveDate>, ended_at_time: Option<NaiveDate>, duration: Option<f64>, is_current: Option<bool>) -> Self {
+        EmploymentEvent{employed_at, started_at_time, ended_at_time, duration, is_current}
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<EmploymentEvent>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<EmploymentEvent> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<EmploymentEvent>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid EmploymentEvent",
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+pub struct MedicalEvent {
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub in_location: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub diagnosis: Option<DiagnosisConcept>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub procedure: Option<ProcedureConcept>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub started_at_time: Option<NaiveDate>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub ended_at_time: Option<NaiveDate>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub duration: Option<f64>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub is_current: Option<bool>
+}
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl MedicalEvent {
+    #[new]
+    pub fn new(in_location: Option<String>, diagnosis: Option<DiagnosisConcept>, procedure: Option<ProcedureConcept>, started_at_time: Option<NaiveDate>, ended_at_time: Option<NaiveDate>, duration: Option<f64>, is_current: Option<bool>) -> Self {
+        MedicalEvent{in_location, diagnosis, procedure, started_at_time, ended_at_time, duration, is_current}
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<MedicalEvent>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<MedicalEvent> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<MedicalEvent>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid MedicalEvent",
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+pub struct WithLocation {
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub in_location: Option<String>
+}
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl WithLocation {
+    #[new]
+    pub fn new(in_location: Option<String>) -> Self {
+        WithLocation{in_location}
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<WithLocation>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<WithLocation> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<WithLocation>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid WithLocation",
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+pub struct Container {
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "serde_utils::deserialize_inlined_dict_list"))]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub persons: Vec<Person>,
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "serde_utils::deserialize_inlined_dict_list"))]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub organizations: Vec<Organization>
+}
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl Container {
+    #[new]
+    pub fn new(persons: Vec<Person>, organizations: Vec<Organization>) -> Self {
+        Container{persons, organizations}
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<Container>
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<Container> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<Container>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid Container",
+        ))
+    }
+}
+
+
+

--- a/examples/PersonSchema/rust/src/poly.rs
+++ b/examples/PersonSchema/rust/src/poly.rs
@@ -6,112 +6,112 @@ use crate::poly_containers::*;
 
 pub trait NamedThing   {
 
-    fn id(&self) -> &String;
-    // fn id_mut(&mut self) -> &mut &String;
+    fn id(&self) -> &str;
+    // fn id_mut(&mut self) -> &mut &str;
     // fn set_id(&mut self, value: String);
 
-    fn name(&self) -> &Option<String>;
-    // fn name_mut(&mut self) -> &mut &Option<String>;
-    // fn set_name(&mut self, value: &Option<String>);
+    fn name(&self) -> Option<&str>;
+    // fn name_mut(&mut self) -> &mut Option<&str>;
+    // fn set_name(&mut self, value: Option<&str>);
 
-    fn description(&self) -> &Option<String>;
-    // fn description_mut(&mut self) -> &mut &Option<String>;
-    // fn set_description(&mut self, value: &Option<String>);
+    fn description(&self) -> Option<&str>;
+    // fn description_mut(&mut self) -> &mut Option<&str>;
+    // fn set_description(&mut self, value: Option<&str>);
 
-    fn image(&self) -> &Option<String>;
-    // fn image_mut(&mut self) -> &mut &Option<String>;
-    // fn set_image(&mut self, value: &Option<String>);
+    fn image(&self) -> Option<&str>;
+    // fn image_mut(&mut self) -> &mut Option<&str>;
+    // fn set_image(&mut self, value: Option<&str>);
 
 
 }
 
 impl NamedThing for crate::NamedThing {
-        fn id(&self) -> &String {
+        fn id(&self) -> &str {
         return &self.id;
     }
-        fn name(&self) -> &Option<String> {
-        return &self.name;
+        fn name(&self) -> Option<&str> {
+        return self.name.as_deref();
     }
-        fn description(&self) -> &Option<String> {
-        return &self.description;
+        fn description(&self) -> Option<&str> {
+        return self.description.as_deref();
     }
-        fn image(&self) -> &Option<String> {
-        return &self.image;
+        fn image(&self) -> Option<&str> {
+        return self.image.as_deref();
     }
 }
 impl NamedThing for crate::Person {
-        fn id(&self) -> &String {
+        fn id(&self) -> &str {
         return &self.id;
     }
-        fn name(&self) -> &Option<String> {
-        return &self.name;
+        fn name(&self) -> Option<&str> {
+        return self.name.as_deref();
     }
-        fn description(&self) -> &Option<String> {
-        return &self.description;
+        fn description(&self) -> Option<&str> {
+        return self.description.as_deref();
     }
-        fn image(&self) -> &Option<String> {
-        return &self.image;
+        fn image(&self) -> Option<&str> {
+        return self.image.as_deref();
     }
 }
 impl NamedThing for crate::Organization {
-        fn id(&self) -> &String {
+        fn id(&self) -> &str {
         return &self.id;
     }
-        fn name(&self) -> &Option<String> {
-        return &self.name;
+        fn name(&self) -> Option<&str> {
+        return self.name.as_deref();
     }
-        fn description(&self) -> &Option<String> {
-        return &self.description;
+        fn description(&self) -> Option<&str> {
+        return self.description.as_deref();
     }
-        fn image(&self) -> &Option<String> {
-        return &self.image;
+        fn image(&self) -> Option<&str> {
+        return self.image.as_deref();
     }
 }
 impl NamedThing for crate::Concept {
-        fn id(&self) -> &String {
+        fn id(&self) -> &str {
         return &self.id;
     }
-        fn name(&self) -> &Option<String> {
-        return &self.name;
+        fn name(&self) -> Option<&str> {
+        return self.name.as_deref();
     }
-        fn description(&self) -> &Option<String> {
-        return &self.description;
+        fn description(&self) -> Option<&str> {
+        return self.description.as_deref();
     }
-        fn image(&self) -> &Option<String> {
-        return &self.image;
+        fn image(&self) -> Option<&str> {
+        return self.image.as_deref();
     }
 }
 impl NamedThing for crate::DiagnosisConcept {
-        fn id(&self) -> &String {
+        fn id(&self) -> &str {
         return &self.id;
     }
-        fn name(&self) -> &Option<String> {
-        return &self.name;
+        fn name(&self) -> Option<&str> {
+        return self.name.as_deref();
     }
-        fn description(&self) -> &Option<String> {
-        return &self.description;
+        fn description(&self) -> Option<&str> {
+        return self.description.as_deref();
     }
-        fn image(&self) -> &Option<String> {
-        return &self.image;
+        fn image(&self) -> Option<&str> {
+        return self.image.as_deref();
     }
 }
 impl NamedThing for crate::ProcedureConcept {
-        fn id(&self) -> &String {
+        fn id(&self) -> &str {
         return &self.id;
     }
-        fn name(&self) -> &Option<String> {
-        return &self.name;
+        fn name(&self) -> Option<&str> {
+        return self.name.as_deref();
     }
-        fn description(&self) -> &Option<String> {
-        return &self.description;
+        fn description(&self) -> Option<&str> {
+        return self.description.as_deref();
     }
-        fn image(&self) -> &Option<String> {
-        return &self.image;
+        fn image(&self) -> Option<&str> {
+        return self.image.as_deref();
     }
 }
 
 impl NamedThing for crate::NamedThingOrSubtype {
-        fn id(&self) -> &String {
+        fn id(&self) -> &str {
         match self {
                 NamedThingOrSubtype::NamedThing(val) => val.id(),
                 NamedThingOrSubtype::Person(val) => val.id(),
@@ -122,7 +122,7 @@ impl NamedThing for crate::NamedThingOrSubtype {
 
         }
     }
-        fn name(&self) -> &Option<String> {
+        fn name(&self) -> Option<&str> {
         match self {
                 NamedThingOrSubtype::NamedThing(val) => val.name(),
                 NamedThingOrSubtype::Person(val) => val.name(),
@@ -133,7 +133,7 @@ impl NamedThing for crate::NamedThingOrSubtype {
 
         }
     }
-        fn description(&self) -> &Option<String> {
+        fn description(&self) -> Option<&str> {
         match self {
                 NamedThingOrSubtype::NamedThing(val) => val.description(),
                 NamedThingOrSubtype::Person(val) => val.description(),
@@ -144,7 +144,7 @@ impl NamedThing for crate::NamedThingOrSubtype {
 
         }
     }
-        fn image(&self) -> &Option<String> {
+        fn image(&self) -> Option<&str> {
         match self {
                 NamedThingOrSubtype::NamedThing(val) => val.image(),
                 NamedThingOrSubtype::Person(val) => val.image(),
@@ -157,7 +157,7 @@ impl NamedThing for crate::NamedThingOrSubtype {
     }
 }
 impl NamedThing for crate::ConceptOrSubtype {
-        fn id(&self) -> &String {
+        fn id(&self) -> &str {
         match self {
                 ConceptOrSubtype::Concept(val) => val.id(),
                 ConceptOrSubtype::DiagnosisConcept(val) => val.id(),
@@ -165,7 +165,7 @@ impl NamedThing for crate::ConceptOrSubtype {
 
         }
     }
-        fn name(&self) -> &Option<String> {
+        fn name(&self) -> Option<&str> {
         match self {
                 ConceptOrSubtype::Concept(val) => val.name(),
                 ConceptOrSubtype::DiagnosisConcept(val) => val.name(),
@@ -173,7 +173,7 @@ impl NamedThing for crate::ConceptOrSubtype {
 
         }
     }
-        fn description(&self) -> &Option<String> {
+        fn description(&self) -> Option<&str> {
         match self {
                 ConceptOrSubtype::Concept(val) => val.description(),
                 ConceptOrSubtype::DiagnosisConcept(val) => val.description(),
@@ -181,7 +181,7 @@ impl NamedThing for crate::ConceptOrSubtype {
 
         }
     }
-        fn image(&self) -> &Option<String> {
+        fn image(&self) -> Option<&str> {
         match self {
                 ConceptOrSubtype::Concept(val) => val.image(),
                 ConceptOrSubtype::DiagnosisConcept(val) => val.image(),
@@ -193,21 +193,21 @@ impl NamedThing for crate::ConceptOrSubtype {
 
 pub trait Person : NamedThing  +  HasAliases   {
 
-    fn primary_email(&self) -> &Option<String>;
-    // fn primary_email_mut(&mut self) -> &mut &Option<String>;
-    // fn set_primary_email(&mut self, value: &Option<String>);
+    fn primary_email(&self) -> Option<&str>;
+    // fn primary_email_mut(&mut self) -> &mut Option<&str>;
+    // fn set_primary_email(&mut self, value: Option<&str>);
 
-    fn birth_date(&self) -> &Option<String>;
-    // fn birth_date_mut(&mut self) -> &mut &Option<String>;
-    // fn set_birth_date(&mut self, value: &Option<String>);
+    fn birth_date(&self) -> Option<&str>;
+    // fn birth_date_mut(&mut self) -> &mut Option<&str>;
+    // fn set_birth_date(&mut self, value: Option<&str>);
 
-    fn age_in_years(&self) -> &Option<isize>;
-    // fn age_in_years_mut(&mut self) -> &mut &Option<isize>;
-    // fn set_age_in_years(&mut self, value: &Option<isize>);
+    fn age_in_years(&self) -> Option<&isize>;
+    // fn age_in_years_mut(&mut self) -> &mut Option<&isize>;
+    // fn set_age_in_years(&mut self, value: Option<&isize>);
 
-    fn gender(&self) -> &Option<String>;
-    // fn gender_mut(&mut self) -> &mut &Option<String>;
-    // fn set_gender(&mut self, value: &Option<String>);
+    fn gender(&self) -> Option<&str>;
+    // fn gender_mut(&mut self) -> &mut Option<&str>;
+    // fn set_gender(&mut self, value: Option<&str>);
 
     fn current_address(&self) -> Option<&crate::Address>;
     // fn current_address_mut(&mut self) -> &mut Option<&crate::Address>;
@@ -229,17 +229,17 @@ pub trait Person : NamedThing  +  HasAliases   {
 }
 
 impl Person for crate::Person {
-        fn primary_email(&self) -> &Option<String> {
-        return &self.primary_email;
+        fn primary_email(&self) -> Option<&str> {
+        return self.primary_email.as_deref();
     }
-        fn birth_date(&self) -> &Option<String> {
-        return &self.birth_date;
+        fn birth_date(&self) -> Option<&str> {
+        return self.birth_date.as_deref();
     }
-        fn age_in_years(&self) -> &Option<isize> {
-        return &self.age_in_years;
+        fn age_in_years(&self) -> Option<&isize> {
+        return self.age_in_years.as_ref();
     }
-        fn gender(&self) -> &Option<String> {
-        return &self.gender;
+        fn gender(&self) -> Option<&str> {
+        return self.gender.as_deref();
     }
         fn current_address(&self) -> Option<&crate::Address> {
         return self.current_address.as_ref();
@@ -301,153 +301,153 @@ impl HasAliases for crate::HasAliasesOrSubtype {
 
 pub trait Organization : NamedThing  +  HasAliases   {
 
-    fn mission_statement(&self) -> &Option<String>;
-    // fn mission_statement_mut(&mut self) -> &mut &Option<String>;
-    // fn set_mission_statement(&mut self, value: &Option<String>);
+    fn mission_statement(&self) -> Option<&str>;
+    // fn mission_statement_mut(&mut self) -> &mut Option<&str>;
+    // fn set_mission_statement(&mut self, value: Option<&str>);
 
-    fn founding_date(&self) -> &Option<String>;
-    // fn founding_date_mut(&mut self) -> &mut &Option<String>;
-    // fn set_founding_date(&mut self, value: &Option<String>);
+    fn founding_date(&self) -> Option<&str>;
+    // fn founding_date_mut(&mut self) -> &mut Option<&str>;
+    // fn set_founding_date(&mut self, value: Option<&str>);
 
-    fn founding_location(&self) -> &Option<String>;
-    // fn founding_location_mut(&mut self) -> &mut &Option<String>;
-    // fn set_founding_location<E>(&mut self, value: &Option<String>) where E: Into<String>;
+    fn founding_location(&self) -> Option<&str>;
+    // fn founding_location_mut(&mut self) -> &mut Option<&str>;
+    // fn set_founding_location<E>(&mut self, value: Option<&str>) where E: Into<String>;
 
 
 }
 
 impl Organization for crate::Organization {
-        fn mission_statement(&self) -> &Option<String> {
-        return &self.mission_statement;
+        fn mission_statement(&self) -> Option<&str> {
+        return self.mission_statement.as_deref();
     }
-        fn founding_date(&self) -> &Option<String> {
-        return &self.founding_date;
+        fn founding_date(&self) -> Option<&str> {
+        return self.founding_date.as_deref();
     }
-        fn founding_location(&self) -> &Option<String> {
-        return &self.founding_location;
+        fn founding_location(&self) -> Option<&str> {
+        return self.founding_location.as_deref();
     }
 }
 
 
 pub trait Place : HasAliases   {
 
-    fn id(&self) -> &String;
-    // fn id_mut(&mut self) -> &mut &String;
+    fn id(&self) -> &str;
+    // fn id_mut(&mut self) -> &mut &str;
     // fn set_id(&mut self, value: String);
 
-    fn name(&self) -> &Option<String>;
-    // fn name_mut(&mut self) -> &mut &Option<String>;
-    // fn set_name(&mut self, value: &Option<String>);
+    fn name(&self) -> Option<&str>;
+    // fn name_mut(&mut self) -> &mut Option<&str>;
+    // fn set_name(&mut self, value: Option<&str>);
 
 
 }
 
 impl Place for crate::Place {
-        fn id(&self) -> &String {
+        fn id(&self) -> &str {
         return &self.id;
     }
-        fn name(&self) -> &Option<String> {
-        return &self.name;
+        fn name(&self) -> Option<&str> {
+        return self.name.as_deref();
     }
 }
 
 
 pub trait Address   {
 
-    fn street(&self) -> &Option<String>;
-    // fn street_mut(&mut self) -> &mut &Option<String>;
-    // fn set_street(&mut self, value: &Option<String>);
+    fn street(&self) -> Option<&str>;
+    // fn street_mut(&mut self) -> &mut Option<&str>;
+    // fn set_street(&mut self, value: Option<&str>);
 
-    fn city(&self) -> &Option<String>;
-    // fn city_mut(&mut self) -> &mut &Option<String>;
-    // fn set_city(&mut self, value: &Option<String>);
+    fn city(&self) -> Option<&str>;
+    // fn city_mut(&mut self) -> &mut Option<&str>;
+    // fn set_city(&mut self, value: Option<&str>);
 
-    fn postal_code(&self) -> &Option<String>;
-    // fn postal_code_mut(&mut self) -> &mut &Option<String>;
-    // fn set_postal_code(&mut self, value: &Option<String>);
+    fn postal_code(&self) -> Option<&str>;
+    // fn postal_code_mut(&mut self) -> &mut Option<&str>;
+    // fn set_postal_code(&mut self, value: Option<&str>);
 
 
 }
 
 impl Address for crate::Address {
-        fn street(&self) -> &Option<String> {
-        return &self.street;
+        fn street(&self) -> Option<&str> {
+        return self.street.as_deref();
     }
-        fn city(&self) -> &Option<String> {
-        return &self.city;
+        fn city(&self) -> Option<&str> {
+        return self.city.as_deref();
     }
-        fn postal_code(&self) -> &Option<String> {
-        return &self.postal_code;
+        fn postal_code(&self) -> Option<&str> {
+        return self.postal_code.as_deref();
     }
 }
 
 
 pub trait Event   {
 
-    fn started_at_time(&self) -> &Option<NaiveDate>;
-    // fn started_at_time_mut(&mut self) -> &mut &Option<NaiveDate>;
-    // fn set_started_at_time(&mut self, value: &Option<NaiveDate>);
+    fn started_at_time(&self) -> Option<&NaiveDate>;
+    // fn started_at_time_mut(&mut self) -> &mut Option<&NaiveDate>;
+    // fn set_started_at_time(&mut self, value: Option<&NaiveDate>);
 
-    fn ended_at_time(&self) -> &Option<NaiveDate>;
-    // fn ended_at_time_mut(&mut self) -> &mut &Option<NaiveDate>;
-    // fn set_ended_at_time(&mut self, value: &Option<NaiveDate>);
+    fn ended_at_time(&self) -> Option<&NaiveDate>;
+    // fn ended_at_time_mut(&mut self) -> &mut Option<&NaiveDate>;
+    // fn set_ended_at_time(&mut self, value: Option<&NaiveDate>);
 
-    fn duration(&self) -> &Option<f64>;
-    // fn duration_mut(&mut self) -> &mut &Option<f64>;
-    // fn set_duration(&mut self, value: &Option<f64>);
+    fn duration(&self) -> Option<&f64>;
+    // fn duration_mut(&mut self) -> &mut Option<&f64>;
+    // fn set_duration(&mut self, value: Option<&f64>);
 
-    fn is_current(&self) -> &Option<bool>;
-    // fn is_current_mut(&mut self) -> &mut &Option<bool>;
-    // fn set_is_current(&mut self, value: &Option<bool>);
+    fn is_current(&self) -> Option<&bool>;
+    // fn is_current_mut(&mut self) -> &mut Option<&bool>;
+    // fn set_is_current(&mut self, value: Option<&bool>);
 
 
 }
 
 impl Event for crate::Event {
-        fn started_at_time(&self) -> &Option<NaiveDate> {
-        return &self.started_at_time;
+        fn started_at_time(&self) -> Option<&NaiveDate> {
+        return self.started_at_time.as_ref();
     }
-        fn ended_at_time(&self) -> &Option<NaiveDate> {
-        return &self.ended_at_time;
+        fn ended_at_time(&self) -> Option<&NaiveDate> {
+        return self.ended_at_time.as_ref();
     }
-        fn duration(&self) -> &Option<f64> {
-        return &self.duration;
+        fn duration(&self) -> Option<&f64> {
+        return self.duration.as_ref();
     }
-        fn is_current(&self) -> &Option<bool> {
-        return &self.is_current;
+        fn is_current(&self) -> Option<&bool> {
+        return self.is_current.as_ref();
     }
 }
 impl Event for crate::EmploymentEvent {
-        fn started_at_time(&self) -> &Option<NaiveDate> {
-        return &self.started_at_time;
+        fn started_at_time(&self) -> Option<&NaiveDate> {
+        return self.started_at_time.as_ref();
     }
-        fn ended_at_time(&self) -> &Option<NaiveDate> {
-        return &self.ended_at_time;
+        fn ended_at_time(&self) -> Option<&NaiveDate> {
+        return self.ended_at_time.as_ref();
     }
-        fn duration(&self) -> &Option<f64> {
-        return &self.duration;
+        fn duration(&self) -> Option<&f64> {
+        return self.duration.as_ref();
     }
-        fn is_current(&self) -> &Option<bool> {
-        return &self.is_current;
+        fn is_current(&self) -> Option<&bool> {
+        return self.is_current.as_ref();
     }
 }
 impl Event for crate::MedicalEvent {
-        fn started_at_time(&self) -> &Option<NaiveDate> {
-        return &self.started_at_time;
+        fn started_at_time(&self) -> Option<&NaiveDate> {
+        return self.started_at_time.as_ref();
     }
-        fn ended_at_time(&self) -> &Option<NaiveDate> {
-        return &self.ended_at_time;
+        fn ended_at_time(&self) -> Option<&NaiveDate> {
+        return self.ended_at_time.as_ref();
     }
-        fn duration(&self) -> &Option<f64> {
-        return &self.duration;
+        fn duration(&self) -> Option<&f64> {
+        return self.duration.as_ref();
     }
-        fn is_current(&self) -> &Option<bool> {
-        return &self.is_current;
+        fn is_current(&self) -> Option<&bool> {
+        return self.is_current.as_ref();
     }
 }
 
 impl Event for crate::EventOrSubtype {
-        fn started_at_time(&self) -> &Option<NaiveDate> {
+        fn started_at_time(&self) -> Option<&NaiveDate> {
         match self {
                 EventOrSubtype::Event(val) => val.started_at_time(),
                 EventOrSubtype::EmploymentEvent(val) => val.started_at_time(),
@@ -455,7 +455,7 @@ impl Event for crate::EventOrSubtype {
 
         }
     }
-        fn ended_at_time(&self) -> &Option<NaiveDate> {
+        fn ended_at_time(&self) -> Option<&NaiveDate> {
         match self {
                 EventOrSubtype::Event(val) => val.ended_at_time(),
                 EventOrSubtype::EmploymentEvent(val) => val.ended_at_time(),
@@ -463,7 +463,7 @@ impl Event for crate::EventOrSubtype {
 
         }
     }
-        fn duration(&self) -> &Option<f64> {
+        fn duration(&self) -> Option<&f64> {
         match self {
                 EventOrSubtype::Event(val) => val.duration(),
                 EventOrSubtype::EmploymentEvent(val) => val.duration(),
@@ -471,7 +471,7 @@ impl Event for crate::EventOrSubtype {
 
         }
     }
-        fn is_current(&self) -> &Option<bool> {
+        fn is_current(&self) -> Option<&bool> {
         match self {
                 EventOrSubtype::Event(val) => val.is_current(),
                 EventOrSubtype::EmploymentEvent(val) => val.is_current(),
@@ -516,77 +516,77 @@ impl ProcedureConcept for crate::ProcedureConcept {
 
 pub trait Relationship   {
 
-    fn started_at_time(&self) -> &Option<NaiveDate>;
-    // fn started_at_time_mut(&mut self) -> &mut &Option<NaiveDate>;
-    // fn set_started_at_time(&mut self, value: &Option<NaiveDate>);
+    fn started_at_time(&self) -> Option<&NaiveDate>;
+    // fn started_at_time_mut(&mut self) -> &mut Option<&NaiveDate>;
+    // fn set_started_at_time(&mut self, value: Option<&NaiveDate>);
 
-    fn ended_at_time(&self) -> &Option<NaiveDate>;
-    // fn ended_at_time_mut(&mut self) -> &mut &Option<NaiveDate>;
-    // fn set_ended_at_time(&mut self, value: &Option<NaiveDate>);
+    fn ended_at_time(&self) -> Option<&NaiveDate>;
+    // fn ended_at_time_mut(&mut self) -> &mut Option<&NaiveDate>;
+    // fn set_ended_at_time(&mut self, value: Option<&NaiveDate>);
 
-    fn related_to(&self) -> &Option<String>;
-    // fn related_to_mut(&mut self) -> &mut &Option<String>;
-    // fn set_related_to(&mut self, value: &Option<String>);
+    fn related_to(&self) -> Option<&str>;
+    // fn related_to_mut(&mut self) -> &mut Option<&str>;
+    // fn set_related_to(&mut self, value: Option<&str>);
 
-    fn type_(&self) -> &Option<String>;
-    // fn type__mut(&mut self) -> &mut &Option<String>;
-    // fn set_type_(&mut self, value: &Option<String>);
+    fn type_(&self) -> Option<&str>;
+    // fn type__mut(&mut self) -> &mut Option<&str>;
+    // fn set_type_(&mut self, value: Option<&str>);
 
 
 }
 
 impl Relationship for crate::Relationship {
-        fn started_at_time(&self) -> &Option<NaiveDate> {
-        return &self.started_at_time;
+        fn started_at_time(&self) -> Option<&NaiveDate> {
+        return self.started_at_time.as_ref();
     }
-        fn ended_at_time(&self) -> &Option<NaiveDate> {
-        return &self.ended_at_time;
+        fn ended_at_time(&self) -> Option<&NaiveDate> {
+        return self.ended_at_time.as_ref();
     }
-        fn related_to(&self) -> &Option<String> {
-        return &self.related_to;
+        fn related_to(&self) -> Option<&str> {
+        return self.related_to.as_deref();
     }
-        fn type_(&self) -> &Option<String> {
-        return &self.type_;
+        fn type_(&self) -> Option<&str> {
+        return self.type_.as_deref();
     }
 }
 impl Relationship for crate::FamilialRelationship {
-        fn started_at_time(&self) -> &Option<NaiveDate> {
-        return &self.started_at_time;
+        fn started_at_time(&self) -> Option<&NaiveDate> {
+        return self.started_at_time.as_ref();
     }
-        fn ended_at_time(&self) -> &Option<NaiveDate> {
-        return &self.ended_at_time;
+        fn ended_at_time(&self) -> Option<&NaiveDate> {
+        return self.ended_at_time.as_ref();
     }
-        fn related_to(&self) -> &Option<String> {
-        return &self.related_to;
+        fn related_to(&self) -> Option<&str> {
+        return Some(&self.related_to);
     }
-        fn type_(&self) -> &Option<String> {
-        return &self.type_;
+        fn type_(&self) -> Option<&str> {
+        return Some(&self.type_);
     }
 }
 
 impl Relationship for crate::RelationshipOrSubtype {
-        fn started_at_time(&self) -> &Option<NaiveDate> {
+        fn started_at_time(&self) -> Option<&NaiveDate> {
         match self {
                 RelationshipOrSubtype::Relationship(val) => val.started_at_time(),
                 RelationshipOrSubtype::FamilialRelationship(val) => val.started_at_time(),
 
         }
     }
-        fn ended_at_time(&self) -> &Option<NaiveDate> {
+        fn ended_at_time(&self) -> Option<&NaiveDate> {
         match self {
                 RelationshipOrSubtype::Relationship(val) => val.ended_at_time(),
                 RelationshipOrSubtype::FamilialRelationship(val) => val.ended_at_time(),
 
         }
     }
-        fn related_to(&self) -> &Option<String> {
+        fn related_to(&self) -> Option<&str> {
         match self {
                 RelationshipOrSubtype::Relationship(val) => val.related_to(),
                 RelationshipOrSubtype::FamilialRelationship(val) => val.related_to(),
 
         }
     }
-        fn type_(&self) -> &Option<String> {
+        fn type_(&self) -> Option<&str> {
         match self {
                 RelationshipOrSubtype::Relationship(val) => val.type_(),
                 RelationshipOrSubtype::FamilialRelationship(val) => val.type_(),
@@ -606,25 +606,25 @@ impl FamilialRelationship for crate::FamilialRelationship {
 
 pub trait EmploymentEvent : Event   {
 
-    fn employed_at(&self) -> &Option<String>;
-    // fn employed_at_mut(&mut self) -> &mut &Option<String>;
-    // fn set_employed_at<E>(&mut self, value: &Option<String>) where E: Into<String>;
+    fn employed_at(&self) -> Option<&str>;
+    // fn employed_at_mut(&mut self) -> &mut Option<&str>;
+    // fn set_employed_at<E>(&mut self, value: Option<&str>) where E: Into<String>;
 
 
 }
 
 impl EmploymentEvent for crate::EmploymentEvent {
-        fn employed_at(&self) -> &Option<String> {
-        return &self.employed_at;
+        fn employed_at(&self) -> Option<&str> {
+        return self.employed_at.as_deref();
     }
 }
 
 
 pub trait MedicalEvent : Event   {
 
-    fn in_location(&self) -> &Option<String>;
-    // fn in_location_mut(&mut self) -> &mut &Option<String>;
-    // fn set_in_location<E>(&mut self, value: &Option<String>) where E: Into<String>;
+    fn in_location(&self) -> Option<&str>;
+    // fn in_location_mut(&mut self) -> &mut Option<&str>;
+    // fn set_in_location<E>(&mut self, value: Option<&str>) where E: Into<String>;
 
     fn diagnosis(&self) -> Option<&crate::DiagnosisConcept>;
     // fn diagnosis_mut(&mut self) -> &mut Option<&crate::DiagnosisConcept>;
@@ -638,8 +638,8 @@ pub trait MedicalEvent : Event   {
 }
 
 impl MedicalEvent for crate::MedicalEvent {
-        fn in_location(&self) -> &Option<String> {
-        return &self.in_location;
+        fn in_location(&self) -> Option<&str> {
+        return self.in_location.as_deref();
     }
         fn diagnosis(&self) -> Option<&crate::DiagnosisConcept> {
         return self.diagnosis.as_ref();
@@ -652,16 +652,16 @@ impl MedicalEvent for crate::MedicalEvent {
 
 pub trait WithLocation   {
 
-    fn in_location(&self) -> &Option<String>;
-    // fn in_location_mut(&mut self) -> &mut &Option<String>;
-    // fn set_in_location<E>(&mut self, value: &Option<String>) where E: Into<String>;
+    fn in_location(&self) -> Option<&str>;
+    // fn in_location_mut(&mut self) -> &mut Option<&str>;
+    // fn set_in_location<E>(&mut self, value: Option<&str>) where E: Into<String>;
 
 
 }
 
 impl WithLocation for crate::WithLocation {
-        fn in_location(&self) -> &Option<String> {
-        return &self.in_location;
+        fn in_location(&self) -> Option<&str> {
+        return self.in_location.as_deref();
     }
 }
 

--- a/examples/PersonSchema/rust/src/poly.rs
+++ b/examples/PersonSchema/rust/src/poly.rs
@@ -1,0 +1,691 @@
+#![allow(non_camel_case_types)]
+
+use crate::*;
+use crate::poly_containers::*;
+
+
+pub trait NamedThing   {
+
+    fn id(&self) -> &String;
+    // fn id_mut(&mut self) -> &mut &String;
+    // fn set_id(&mut self, value: String);
+
+    fn name(&self) -> &Option<String>;
+    // fn name_mut(&mut self) -> &mut &Option<String>;
+    // fn set_name(&mut self, value: &Option<String>);
+
+    fn description(&self) -> &Option<String>;
+    // fn description_mut(&mut self) -> &mut &Option<String>;
+    // fn set_description(&mut self, value: &Option<String>);
+
+    fn image(&self) -> &Option<String>;
+    // fn image_mut(&mut self) -> &mut &Option<String>;
+    // fn set_image(&mut self, value: &Option<String>);
+
+
+}
+
+impl NamedThing for crate::NamedThing {
+        fn id(&self) -> &String {
+        return &self.id;
+    }
+        fn name(&self) -> &Option<String> {
+        return &self.name;
+    }
+        fn description(&self) -> &Option<String> {
+        return &self.description;
+    }
+        fn image(&self) -> &Option<String> {
+        return &self.image;
+    }
+}
+impl NamedThing for crate::Person {
+        fn id(&self) -> &String {
+        return &self.id;
+    }
+        fn name(&self) -> &Option<String> {
+        return &self.name;
+    }
+        fn description(&self) -> &Option<String> {
+        return &self.description;
+    }
+        fn image(&self) -> &Option<String> {
+        return &self.image;
+    }
+}
+impl NamedThing for crate::Organization {
+        fn id(&self) -> &String {
+        return &self.id;
+    }
+        fn name(&self) -> &Option<String> {
+        return &self.name;
+    }
+        fn description(&self) -> &Option<String> {
+        return &self.description;
+    }
+        fn image(&self) -> &Option<String> {
+        return &self.image;
+    }
+}
+impl NamedThing for crate::Concept {
+        fn id(&self) -> &String {
+        return &self.id;
+    }
+        fn name(&self) -> &Option<String> {
+        return &self.name;
+    }
+        fn description(&self) -> &Option<String> {
+        return &self.description;
+    }
+        fn image(&self) -> &Option<String> {
+        return &self.image;
+    }
+}
+impl NamedThing for crate::DiagnosisConcept {
+        fn id(&self) -> &String {
+        return &self.id;
+    }
+        fn name(&self) -> &Option<String> {
+        return &self.name;
+    }
+        fn description(&self) -> &Option<String> {
+        return &self.description;
+    }
+        fn image(&self) -> &Option<String> {
+        return &self.image;
+    }
+}
+impl NamedThing for crate::ProcedureConcept {
+        fn id(&self) -> &String {
+        return &self.id;
+    }
+        fn name(&self) -> &Option<String> {
+        return &self.name;
+    }
+        fn description(&self) -> &Option<String> {
+        return &self.description;
+    }
+        fn image(&self) -> &Option<String> {
+        return &self.image;
+    }
+}
+
+impl NamedThing for crate::NamedThingOrSubtype {
+        fn id(&self) -> &String {
+        match self {
+                NamedThingOrSubtype::NamedThing(val) => val.id(),
+                NamedThingOrSubtype::Person(val) => val.id(),
+                NamedThingOrSubtype::Organization(val) => val.id(),
+                NamedThingOrSubtype::Concept(val) => val.id(),
+                NamedThingOrSubtype::DiagnosisConcept(val) => val.id(),
+                NamedThingOrSubtype::ProcedureConcept(val) => val.id(),
+
+        }
+    }
+        fn name(&self) -> &Option<String> {
+        match self {
+                NamedThingOrSubtype::NamedThing(val) => val.name(),
+                NamedThingOrSubtype::Person(val) => val.name(),
+                NamedThingOrSubtype::Organization(val) => val.name(),
+                NamedThingOrSubtype::Concept(val) => val.name(),
+                NamedThingOrSubtype::DiagnosisConcept(val) => val.name(),
+                NamedThingOrSubtype::ProcedureConcept(val) => val.name(),
+
+        }
+    }
+        fn description(&self) -> &Option<String> {
+        match self {
+                NamedThingOrSubtype::NamedThing(val) => val.description(),
+                NamedThingOrSubtype::Person(val) => val.description(),
+                NamedThingOrSubtype::Organization(val) => val.description(),
+                NamedThingOrSubtype::Concept(val) => val.description(),
+                NamedThingOrSubtype::DiagnosisConcept(val) => val.description(),
+                NamedThingOrSubtype::ProcedureConcept(val) => val.description(),
+
+        }
+    }
+        fn image(&self) -> &Option<String> {
+        match self {
+                NamedThingOrSubtype::NamedThing(val) => val.image(),
+                NamedThingOrSubtype::Person(val) => val.image(),
+                NamedThingOrSubtype::Organization(val) => val.image(),
+                NamedThingOrSubtype::Concept(val) => val.image(),
+                NamedThingOrSubtype::DiagnosisConcept(val) => val.image(),
+                NamedThingOrSubtype::ProcedureConcept(val) => val.image(),
+
+        }
+    }
+}
+impl NamedThing for crate::ConceptOrSubtype {
+        fn id(&self) -> &String {
+        match self {
+                ConceptOrSubtype::Concept(val) => val.id(),
+                ConceptOrSubtype::DiagnosisConcept(val) => val.id(),
+                ConceptOrSubtype::ProcedureConcept(val) => val.id(),
+
+        }
+    }
+        fn name(&self) -> &Option<String> {
+        match self {
+                ConceptOrSubtype::Concept(val) => val.name(),
+                ConceptOrSubtype::DiagnosisConcept(val) => val.name(),
+                ConceptOrSubtype::ProcedureConcept(val) => val.name(),
+
+        }
+    }
+        fn description(&self) -> &Option<String> {
+        match self {
+                ConceptOrSubtype::Concept(val) => val.description(),
+                ConceptOrSubtype::DiagnosisConcept(val) => val.description(),
+                ConceptOrSubtype::ProcedureConcept(val) => val.description(),
+
+        }
+    }
+        fn image(&self) -> &Option<String> {
+        match self {
+                ConceptOrSubtype::Concept(val) => val.image(),
+                ConceptOrSubtype::DiagnosisConcept(val) => val.image(),
+                ConceptOrSubtype::ProcedureConcept(val) => val.image(),
+
+        }
+    }
+}
+
+pub trait Person : NamedThing  +  HasAliases   {
+
+    fn primary_email(&self) -> &Option<String>;
+    // fn primary_email_mut(&mut self) -> &mut &Option<String>;
+    // fn set_primary_email(&mut self, value: &Option<String>);
+
+    fn birth_date(&self) -> &Option<String>;
+    // fn birth_date_mut(&mut self) -> &mut &Option<String>;
+    // fn set_birth_date(&mut self, value: &Option<String>);
+
+    fn age_in_years(&self) -> &Option<isize>;
+    // fn age_in_years_mut(&mut self) -> &mut &Option<isize>;
+    // fn set_age_in_years(&mut self, value: &Option<isize>);
+
+    fn gender(&self) -> &Option<String>;
+    // fn gender_mut(&mut self) -> &mut &Option<String>;
+    // fn set_gender(&mut self, value: &Option<String>);
+
+    fn current_address(&self) -> Option<&crate::Address>;
+    // fn current_address_mut(&mut self) -> &mut Option<&crate::Address>;
+    // fn set_current_address<E>(&mut self, value: Option<E>) where E: Into<Address>;
+
+    fn has_employment_history(&self) -> impl poly_containers::SeqRef<crate::EmploymentEvent>;
+    // fn has_employment_history_mut(&mut self) -> &mut impl poly_containers::SeqRef<crate::EmploymentEvent>;
+    // fn set_has_employment_history<E>(&mut self, value: &Vec<E>) where E: Into<EmploymentEvent>;
+
+    fn has_familial_relationships(&self) -> impl poly_containers::SeqRef<crate::FamilialRelationship>;
+    // fn has_familial_relationships_mut(&mut self) -> &mut impl poly_containers::SeqRef<crate::FamilialRelationship>;
+    // fn set_has_familial_relationships<E>(&mut self, value: &Vec<E>) where E: Into<FamilialRelationship>;
+
+    fn has_medical_history(&self) -> impl poly_containers::SeqRef<crate::MedicalEvent>;
+    // fn has_medical_history_mut(&mut self) -> &mut impl poly_containers::SeqRef<crate::MedicalEvent>;
+    // fn set_has_medical_history<E>(&mut self, value: &Vec<E>) where E: Into<MedicalEvent>;
+
+
+}
+
+impl Person for crate::Person {
+        fn primary_email(&self) -> &Option<String> {
+        return &self.primary_email;
+    }
+        fn birth_date(&self) -> &Option<String> {
+        return &self.birth_date;
+    }
+        fn age_in_years(&self) -> &Option<isize> {
+        return &self.age_in_years;
+    }
+        fn gender(&self) -> &Option<String> {
+        return &self.gender;
+    }
+        fn current_address(&self) -> Option<&crate::Address> {
+        return self.current_address.as_ref();
+    }
+        fn has_employment_history(&self) -> impl poly_containers::SeqRef<crate::EmploymentEvent> {
+        return &self.has_employment_history;
+    }
+        fn has_familial_relationships(&self) -> impl poly_containers::SeqRef<crate::FamilialRelationship> {
+// list
+        return poly_containers::ListView::new(&self.has_familial_relationships);
+    }
+        fn has_medical_history(&self) -> impl poly_containers::SeqRef<crate::MedicalEvent> {
+        return &self.has_medical_history;
+    }
+}
+
+
+pub trait HasAliases   {
+
+    fn aliases(&self) -> impl poly_containers::SeqRef<String>;
+    // fn aliases_mut(&mut self) -> &mut impl poly_containers::SeqRef<String>;
+    // fn set_aliases(&mut self, value: &Vec<String>);
+
+
+}
+
+impl HasAliases for crate::HasAliases {
+        fn aliases(&self) -> impl poly_containers::SeqRef<String> {
+        return &self.aliases;
+    }
+}
+impl HasAliases for crate::Person {
+        fn aliases(&self) -> impl poly_containers::SeqRef<String> {
+        return &self.aliases;
+    }
+}
+impl HasAliases for crate::Organization {
+        fn aliases(&self) -> impl poly_containers::SeqRef<String> {
+        return &self.aliases;
+    }
+}
+impl HasAliases for crate::Place {
+        fn aliases(&self) -> impl poly_containers::SeqRef<String> {
+        return &self.aliases;
+    }
+}
+
+impl HasAliases for crate::HasAliasesOrSubtype {
+        fn aliases(&self) -> impl poly_containers::SeqRef<String> {
+        match self {
+                HasAliasesOrSubtype::HasAliases(val) => val.aliases().to_any(),
+                HasAliasesOrSubtype::Person(val) => val.aliases().to_any(),
+                HasAliasesOrSubtype::Organization(val) => val.aliases().to_any(),
+                HasAliasesOrSubtype::Place(val) => val.aliases().to_any(),
+
+        }
+    }
+}
+
+pub trait Organization : NamedThing  +  HasAliases   {
+
+    fn mission_statement(&self) -> &Option<String>;
+    // fn mission_statement_mut(&mut self) -> &mut &Option<String>;
+    // fn set_mission_statement(&mut self, value: &Option<String>);
+
+    fn founding_date(&self) -> &Option<String>;
+    // fn founding_date_mut(&mut self) -> &mut &Option<String>;
+    // fn set_founding_date(&mut self, value: &Option<String>);
+
+    fn founding_location(&self) -> &Option<String>;
+    // fn founding_location_mut(&mut self) -> &mut &Option<String>;
+    // fn set_founding_location<E>(&mut self, value: &Option<String>) where E: Into<String>;
+
+
+}
+
+impl Organization for crate::Organization {
+        fn mission_statement(&self) -> &Option<String> {
+        return &self.mission_statement;
+    }
+        fn founding_date(&self) -> &Option<String> {
+        return &self.founding_date;
+    }
+        fn founding_location(&self) -> &Option<String> {
+        return &self.founding_location;
+    }
+}
+
+
+pub trait Place : HasAliases   {
+
+    fn id(&self) -> &String;
+    // fn id_mut(&mut self) -> &mut &String;
+    // fn set_id(&mut self, value: String);
+
+    fn name(&self) -> &Option<String>;
+    // fn name_mut(&mut self) -> &mut &Option<String>;
+    // fn set_name(&mut self, value: &Option<String>);
+
+
+}
+
+impl Place for crate::Place {
+        fn id(&self) -> &String {
+        return &self.id;
+    }
+        fn name(&self) -> &Option<String> {
+        return &self.name;
+    }
+}
+
+
+pub trait Address   {
+
+    fn street(&self) -> &Option<String>;
+    // fn street_mut(&mut self) -> &mut &Option<String>;
+    // fn set_street(&mut self, value: &Option<String>);
+
+    fn city(&self) -> &Option<String>;
+    // fn city_mut(&mut self) -> &mut &Option<String>;
+    // fn set_city(&mut self, value: &Option<String>);
+
+    fn postal_code(&self) -> &Option<String>;
+    // fn postal_code_mut(&mut self) -> &mut &Option<String>;
+    // fn set_postal_code(&mut self, value: &Option<String>);
+
+
+}
+
+impl Address for crate::Address {
+        fn street(&self) -> &Option<String> {
+        return &self.street;
+    }
+        fn city(&self) -> &Option<String> {
+        return &self.city;
+    }
+        fn postal_code(&self) -> &Option<String> {
+        return &self.postal_code;
+    }
+}
+
+
+pub trait Event   {
+
+    fn started_at_time(&self) -> &Option<NaiveDate>;
+    // fn started_at_time_mut(&mut self) -> &mut &Option<NaiveDate>;
+    // fn set_started_at_time(&mut self, value: &Option<NaiveDate>);
+
+    fn ended_at_time(&self) -> &Option<NaiveDate>;
+    // fn ended_at_time_mut(&mut self) -> &mut &Option<NaiveDate>;
+    // fn set_ended_at_time(&mut self, value: &Option<NaiveDate>);
+
+    fn duration(&self) -> &Option<f64>;
+    // fn duration_mut(&mut self) -> &mut &Option<f64>;
+    // fn set_duration(&mut self, value: &Option<f64>);
+
+    fn is_current(&self) -> &Option<bool>;
+    // fn is_current_mut(&mut self) -> &mut &Option<bool>;
+    // fn set_is_current(&mut self, value: &Option<bool>);
+
+
+}
+
+impl Event for crate::Event {
+        fn started_at_time(&self) -> &Option<NaiveDate> {
+        return &self.started_at_time;
+    }
+        fn ended_at_time(&self) -> &Option<NaiveDate> {
+        return &self.ended_at_time;
+    }
+        fn duration(&self) -> &Option<f64> {
+        return &self.duration;
+    }
+        fn is_current(&self) -> &Option<bool> {
+        return &self.is_current;
+    }
+}
+impl Event for crate::EmploymentEvent {
+        fn started_at_time(&self) -> &Option<NaiveDate> {
+        return &self.started_at_time;
+    }
+        fn ended_at_time(&self) -> &Option<NaiveDate> {
+        return &self.ended_at_time;
+    }
+        fn duration(&self) -> &Option<f64> {
+        return &self.duration;
+    }
+        fn is_current(&self) -> &Option<bool> {
+        return &self.is_current;
+    }
+}
+impl Event for crate::MedicalEvent {
+        fn started_at_time(&self) -> &Option<NaiveDate> {
+        return &self.started_at_time;
+    }
+        fn ended_at_time(&self) -> &Option<NaiveDate> {
+        return &self.ended_at_time;
+    }
+        fn duration(&self) -> &Option<f64> {
+        return &self.duration;
+    }
+        fn is_current(&self) -> &Option<bool> {
+        return &self.is_current;
+    }
+}
+
+impl Event for crate::EventOrSubtype {
+        fn started_at_time(&self) -> &Option<NaiveDate> {
+        match self {
+                EventOrSubtype::Event(val) => val.started_at_time(),
+                EventOrSubtype::EmploymentEvent(val) => val.started_at_time(),
+                EventOrSubtype::MedicalEvent(val) => val.started_at_time(),
+
+        }
+    }
+        fn ended_at_time(&self) -> &Option<NaiveDate> {
+        match self {
+                EventOrSubtype::Event(val) => val.ended_at_time(),
+                EventOrSubtype::EmploymentEvent(val) => val.ended_at_time(),
+                EventOrSubtype::MedicalEvent(val) => val.ended_at_time(),
+
+        }
+    }
+        fn duration(&self) -> &Option<f64> {
+        match self {
+                EventOrSubtype::Event(val) => val.duration(),
+                EventOrSubtype::EmploymentEvent(val) => val.duration(),
+                EventOrSubtype::MedicalEvent(val) => val.duration(),
+
+        }
+    }
+        fn is_current(&self) -> &Option<bool> {
+        match self {
+                EventOrSubtype::Event(val) => val.is_current(),
+                EventOrSubtype::EmploymentEvent(val) => val.is_current(),
+                EventOrSubtype::MedicalEvent(val) => val.is_current(),
+
+        }
+    }
+}
+
+pub trait Concept : NamedThing   {
+
+
+}
+
+impl Concept for crate::Concept {
+}
+impl Concept for crate::DiagnosisConcept {
+}
+impl Concept for crate::ProcedureConcept {
+}
+
+impl Concept for crate::ConceptOrSubtype {
+}
+
+pub trait DiagnosisConcept : Concept   {
+
+
+}
+
+impl DiagnosisConcept for crate::DiagnosisConcept {
+}
+
+
+pub trait ProcedureConcept : Concept   {
+
+
+}
+
+impl ProcedureConcept for crate::ProcedureConcept {
+}
+
+
+pub trait Relationship   {
+
+    fn started_at_time(&self) -> &Option<NaiveDate>;
+    // fn started_at_time_mut(&mut self) -> &mut &Option<NaiveDate>;
+    // fn set_started_at_time(&mut self, value: &Option<NaiveDate>);
+
+    fn ended_at_time(&self) -> &Option<NaiveDate>;
+    // fn ended_at_time_mut(&mut self) -> &mut &Option<NaiveDate>;
+    // fn set_ended_at_time(&mut self, value: &Option<NaiveDate>);
+
+    fn related_to(&self) -> &Option<String>;
+    // fn related_to_mut(&mut self) -> &mut &Option<String>;
+    // fn set_related_to(&mut self, value: &Option<String>);
+
+    fn type_(&self) -> &Option<String>;
+    // fn type__mut(&mut self) -> &mut &Option<String>;
+    // fn set_type_(&mut self, value: &Option<String>);
+
+
+}
+
+impl Relationship for crate::Relationship {
+        fn started_at_time(&self) -> &Option<NaiveDate> {
+        return &self.started_at_time;
+    }
+        fn ended_at_time(&self) -> &Option<NaiveDate> {
+        return &self.ended_at_time;
+    }
+        fn related_to(&self) -> &Option<String> {
+        return &self.related_to;
+    }
+        fn type_(&self) -> &Option<String> {
+        return &self.type_;
+    }
+}
+impl Relationship for crate::FamilialRelationship {
+        fn started_at_time(&self) -> &Option<NaiveDate> {
+        return &self.started_at_time;
+    }
+        fn ended_at_time(&self) -> &Option<NaiveDate> {
+        return &self.ended_at_time;
+    }
+        fn related_to(&self) -> &Option<String> {
+        return &self.related_to;
+    }
+        fn type_(&self) -> &Option<String> {
+        return &self.type_;
+    }
+}
+
+impl Relationship for crate::RelationshipOrSubtype {
+        fn started_at_time(&self) -> &Option<NaiveDate> {
+        match self {
+                RelationshipOrSubtype::Relationship(val) => val.started_at_time(),
+                RelationshipOrSubtype::FamilialRelationship(val) => val.started_at_time(),
+
+        }
+    }
+        fn ended_at_time(&self) -> &Option<NaiveDate> {
+        match self {
+                RelationshipOrSubtype::Relationship(val) => val.ended_at_time(),
+                RelationshipOrSubtype::FamilialRelationship(val) => val.ended_at_time(),
+
+        }
+    }
+        fn related_to(&self) -> &Option<String> {
+        match self {
+                RelationshipOrSubtype::Relationship(val) => val.related_to(),
+                RelationshipOrSubtype::FamilialRelationship(val) => val.related_to(),
+
+        }
+    }
+        fn type_(&self) -> &Option<String> {
+        match self {
+                RelationshipOrSubtype::Relationship(val) => val.type_(),
+                RelationshipOrSubtype::FamilialRelationship(val) => val.type_(),
+
+        }
+    }
+}
+
+pub trait FamilialRelationship : Relationship   {
+
+
+}
+
+impl FamilialRelationship for crate::FamilialRelationship {
+}
+
+
+pub trait EmploymentEvent : Event   {
+
+    fn employed_at(&self) -> &Option<String>;
+    // fn employed_at_mut(&mut self) -> &mut &Option<String>;
+    // fn set_employed_at<E>(&mut self, value: &Option<String>) where E: Into<String>;
+
+
+}
+
+impl EmploymentEvent for crate::EmploymentEvent {
+        fn employed_at(&self) -> &Option<String> {
+        return &self.employed_at;
+    }
+}
+
+
+pub trait MedicalEvent : Event   {
+
+    fn in_location(&self) -> &Option<String>;
+    // fn in_location_mut(&mut self) -> &mut &Option<String>;
+    // fn set_in_location<E>(&mut self, value: &Option<String>) where E: Into<String>;
+
+    fn diagnosis(&self) -> Option<&crate::DiagnosisConcept>;
+    // fn diagnosis_mut(&mut self) -> &mut Option<&crate::DiagnosisConcept>;
+    // fn set_diagnosis<E>(&mut self, value: Option<E>) where E: Into<DiagnosisConcept>;
+
+    fn procedure(&self) -> Option<&crate::ProcedureConcept>;
+    // fn procedure_mut(&mut self) -> &mut Option<&crate::ProcedureConcept>;
+    // fn set_procedure<E>(&mut self, value: Option<E>) where E: Into<ProcedureConcept>;
+
+
+}
+
+impl MedicalEvent for crate::MedicalEvent {
+        fn in_location(&self) -> &Option<String> {
+        return &self.in_location;
+    }
+        fn diagnosis(&self) -> Option<&crate::DiagnosisConcept> {
+        return self.diagnosis.as_ref();
+    }
+        fn procedure(&self) -> Option<&crate::ProcedureConcept> {
+        return self.procedure.as_ref();
+    }
+}
+
+
+pub trait WithLocation   {
+
+    fn in_location(&self) -> &Option<String>;
+    // fn in_location_mut(&mut self) -> &mut &Option<String>;
+    // fn set_in_location<E>(&mut self, value: &Option<String>) where E: Into<String>;
+
+
+}
+
+impl WithLocation for crate::WithLocation {
+        fn in_location(&self) -> &Option<String> {
+        return &self.in_location;
+    }
+}
+
+
+pub trait Container   {
+
+    fn persons(&self) -> impl poly_containers::SeqRef<crate::Person>;
+    // fn persons_mut(&mut self) -> &mut impl poly_containers::SeqRef<crate::Person>;
+    // fn set_persons<E>(&mut self, value: &Vec<E>) where E: Into<Person>;
+
+    fn organizations(&self) -> impl poly_containers::SeqRef<crate::Organization>;
+    // fn organizations_mut(&mut self) -> &mut impl poly_containers::SeqRef<crate::Organization>;
+    // fn set_organizations<E>(&mut self, value: &Vec<E>) where E: Into<Organization>;
+
+
+}
+
+impl Container for crate::Container {
+        fn persons(&self) -> impl poly_containers::SeqRef<crate::Person> {
+        return &self.persons;
+    }
+        fn organizations(&self) -> impl poly_containers::SeqRef<crate::Organization> {
+        return &self.organizations;
+    }
+}
+
+

--- a/examples/PersonSchema/rust/src/poly_containers.rs
+++ b/examples/PersonSchema/rust/src/poly_containers.rs
@@ -1,0 +1,439 @@
+use std::{
+    hash::Hash,
+    collections::HashMap,
+    iter::{Map, IntoIterator},
+    ops::{Index, IndexMut},
+    slice,
+};
+
+/* ------------------------------------------------------------------- *
+ *  Immutable view
+ * ------------------------------------------------------------------- */
+
+ pub struct ListView<'a, T> {
+    inner: &'a [Box<T>],
+}
+
+type ViewIter<'a, T> =
+    std::iter::Map<
+        std::slice::Iter<'a, Box<T>>,
+        fn(&'a Box<T>) -> &'a T,
+    >;
+
+
+impl<'a, T> ListView<'a, T> {
+
+    pub fn len(&self) -> usize        { self.inner.len() }
+    pub fn is_empty(&self) -> bool    { self.inner.is_empty() }
+
+    pub fn get(&self, i: usize) -> Option<&T> {
+        self.inner.get(i).map(|b| &**b)
+    }
+
+    pub fn new(inner: &'a [Box<T>]) -> ListView<'a, T> {
+        Self { inner : inner }
+    }
+
+
+    pub fn iter(&self) -> ViewIter<'a, T> {
+        self.inner.iter().map(debox)
+    }
+}
+
+/* Index (`view[i]`) */
+impl<'a, T> Index<usize> for ListView<'a, T> {
+    type Output = T;
+    fn index(&self, i: usize) -> &Self::Output { &*self.inner[i] }
+}
+
+/* &ListView iteration  (`for x in &view`) */
+type Iter<'a, T> = Map<slice::Iter<'a, Box<T>>, fn(&'a Box<T>) -> &'a T>;
+fn debox<'a, T>(b: &'a Box<T>) -> &'a T { &**b }
+
+impl<'a, T> IntoIterator for &'a ListView<'a, T> {
+    type Item     = &'a T;
+    type IntoIter = Iter<'a, T>;
+    fn into_iter(self) -> Self::IntoIter { self.inner.iter().map(debox) }
+}
+
+/* ------------------------------------------------------------------- *
+ *  Mutable view
+ * ------------------------------------------------------------------- */
+
+pub struct ListViewMut<'a, T> {
+    inner: &'a mut Vec<Box<T>>,
+}
+
+impl<'a, T> ListViewMut<'a, T> {
+    pub fn len(&self) -> usize        { self.inner.len() }
+    pub fn is_empty(&self) -> bool    { self.inner.is_empty() }
+
+    pub fn new(inner: &'a mut Vec<Box<T>>) -> ListViewMut<'a, T> {
+        Self { inner : inner }
+    }
+
+    pub fn get(&self, i: usize) -> Option<&T> {
+        self.inner.get(i).map(|b| &**b)
+    }
+    pub fn get_mut(&mut self, i: usize) -> Option<&mut T> {
+        self.inner.get_mut(i).map(|b| &mut **b)
+    }
+
+    pub fn push(&mut self, v: T) {
+        self.inner.push(Box::new(v));
+    }
+
+    pub fn iter(&self) -> Iter<'_, T> {
+        self.inner.iter().map(debox)
+    }
+    pub fn iter_mut(&mut self) -> IterMut<'_, T> {
+        self.inner.iter_mut().map(debox_mut)
+    }
+}
+
+/* Index / IndexMut */
+impl<'a, T> Index<usize> for ListViewMut<'a, T> {
+    type Output = T;
+    fn index(&self, i: usize) -> &Self::Output { &*self.inner[i] }
+}
+impl<'a, T> IndexMut<usize> for ListViewMut<'a, T> {
+    fn index_mut(&mut self, i: usize) -> &mut Self::Output { &mut *self.inner[i] }
+}
+
+/* &mut ListViewMut iteration (`for x in &mut view`) */
+fn debox_mut<'a, T>(b: &'a mut Box<T>) -> &'a mut T { &mut **b }
+type IterMut<'a, T> = Map<slice::IterMut<'a, Box<T>>, fn(&'a mut Box<T>) -> &'a mut T>;
+
+impl<'a, T> IntoIterator for &'a ListViewMut<'a, T> {
+    type Item     = &'a T;
+    type IntoIter = Iter<'a, T>;
+    fn into_iter(self) -> Self::IntoIter { self.inner.iter().map(debox) }
+}
+impl<'a, T> IntoIterator for &'a mut ListViewMut<'a, T> {
+    type Item     = &'a mut T;
+    type IntoIter = IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter { self.inner.iter_mut().map(debox_mut) }
+}
+
+
+pub struct MapView<'a, K, V> {
+    inner: &'a HashMap<K, Box<V>>,
+}
+
+impl<'a, K: Eq + Hash, V> MapView<'a, K, V> {
+    /* basic info */
+    pub fn len(&self) -> usize        { self.inner.len() }
+    pub fn is_empty(&self) -> bool    { self.inner.is_empty() }
+
+    /* look-ups */
+    pub fn get(&self, k: &K) -> Option<&V> {
+        self.inner.get(k).map(debox)
+    }
+
+    pub fn new(inner: &'a HashMap<K, Box<V>>)  -> Self {
+        Self { inner : inner }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> + '_ {
+        self.inner.iter().map(as_pair)
+    }
+
+}
+
+/* &MapView iteration */
+type MapIter<'a, K, V> =
+    Map<std::collections::hash_map::Iter<'a, K, Box<V>>, fn((&'a K,&'a Box<V>)) -> (&'a K,&'a V)>;
+
+fn as_pair<'a, K, V>((k, v): (&'a K, &'a Box<V>)) -> (&'a K, &'a V) { (k, &**v) }
+
+impl<'a, K: Eq + Hash, V> IntoIterator for &'a MapView<'a, K, V> {
+    type Item     = (&'a K, &'a V);
+    type IntoIter = MapIter<'a, K, V>;
+    fn into_iter(self) -> Self::IntoIter { self.inner.iter().map(as_pair) }
+}
+
+/* ─────────────────────────────── mutable view ────────────────────── */
+pub struct MapViewMut<'a, K, V> {
+    inner: &'a mut HashMap<K, Box<V>>,
+}
+
+impl<'a, K: Eq + Hash, V> MapViewMut<'a, K, V> {
+    /* same basic info */
+    pub fn len(&self) -> usize        { self.inner.len() }
+    pub fn is_empty(&self) -> bool    { self.inner.is_empty() }
+
+    /* look-ups */
+    pub fn get(&self,  k: &K) -> Option<&V>       { self.inner.get(k).map(debox) }
+    pub fn get_mut(&mut self, k: &K) -> Option<&mut V> { self.inner.get_mut(k).map(debox_mut) }
+
+    /* insertion / removal */
+    pub fn insert(&mut self, k: K, v: V) -> Option<V> {
+        self.inner.insert(k, Box::new(v)).map(|old| *old)
+    }
+    pub fn remove(&mut self, k: &K) -> Option<V> {
+        self.inner.remove(k).map(|b| *b)
+    }
+
+    /* iterators */
+    pub fn iter<'b>(&'b self) -> MapIter<'b, K, V> {
+        self.inner.iter().map(as_pair)
+    }
+    pub fn iter_mut<'b>(&'b mut self) -> MapIterMut<'b, K, V> {
+        self.inner.iter_mut().map(as_pair_mut)
+    }
+}
+
+/* &mut MapViewMut iteration */
+type MapIterMut<'a, K, V> =
+    Map<std::collections::hash_map::IterMut<'a, K, Box<V>>,
+        fn((&'a K,&'a mut Box<V>)) -> (&'a K,&'a mut V)>;
+
+fn as_pair_mut<'a, K, V>((k, v): (&'a K, &'a mut Box<V>)) -> (&'a K, &'a mut V) { (k, &mut **v) }
+
+impl<'a, K: Eq + Hash, V> IntoIterator for &'a mut MapViewMut<'a, K, V> {
+    type Item     = (&'a K, &'a mut V);
+    type IntoIter = MapIterMut<'a, K, V>;
+    fn into_iter(self) -> Self::IntoIter { self.inner.iter_mut().map(as_pair_mut) }
+}
+/* also allow &MapViewMut to iterate immutably */
+impl<'a, K: Eq + Hash, V> IntoIterator for &'a MapViewMut<'a, K, V> {
+    type Item     = (&'a K, &'a V);
+    type IntoIter = MapIter<'a, K, V>;
+    fn into_iter(self) -> Self::IntoIter { self.inner.iter().map(as_pair) }
+}
+
+
+pub trait MapRef<'l, K, V> {
+    fn get(&self, k: &K) -> Option<&V>;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool { self.len() == 0 }
+
+    type Iter<'a>: Iterator<Item = (&'a K, &'a V)>
+    where
+        Self: 'a,
+        K: 'a,
+        V: 'a;
+
+    fn iter(&self) -> Self::Iter<'_>;
+
+    fn to_any(self) -> MapAny<'l, K, V>
+    where
+        Self: Sized;        // keeps it object-safe enough for static dispatch
+}
+
+
+/* NEW — borrowed map */
+impl<'a, K: Eq + Hash, V> MapRef<'a, K, V> for &'a HashMap<K, V> {
+    fn get(&self, k: &K) -> Option<&V> { (*self).get(k) }
+    fn len(&self) -> usize             { (*self).len() }
+
+    type Iter<'b> = std::collections::hash_map::Iter<'b, K, V>
+    where
+        Self: 'b,
+        K: 'b,
+        V: 'b;
+
+    fn iter(&self) -> Self::Iter<'a> {
+        (*self).iter()
+    }
+    fn to_any(self) -> MapAny<'a, K, V>
+    where
+        Self: Sized
+     {
+        MapAny::Hash(self)
+    }
+}
+
+/* ---- impl for your borrowing MapView ---------------------------- */
+impl<'a, K: std::hash::Hash + Eq, V> MapRef<'a, K, V> for MapView<'a, K, V> {
+    fn get(&self, k: &K) -> Option<&V> { self.inner.get(k).map(|b| &**b) }
+    fn len(&self) -> usize { self.inner.len() }
+
+    type Iter<'b> =
+        std::iter::Map<
+            std::collections::hash_map::Iter<'b, K, Box<V>>,
+            fn((&'b K,&'b Box<V>)) -> (&'b K,&'b V)
+        > where K: 'b, V: 'b, Self: 'b;
+
+    fn iter(&self) -> Self::Iter<'_> {
+        fn as_pair<'b, K, V>((k, v): (&'b K, &'b Box<V>)) -> (&'b K, &'b V) { (k, &**v) }
+        self.inner.iter().map(as_pair)
+    }
+    fn to_any(self) -> MapAny<'a, K, V>
+    where
+        Self: Sized
+     {
+        MapAny::View(MapView { inner : self.inner })
+    }
+}
+
+
+
+pub trait SeqRef<'l, T> {
+    /// Immutable iterator (`for x in seq.iter()`)
+    type Iter<'a>: Iterator<Item = &'a T> + ExactSizeIterator
+    where
+        Self: 'a,
+        T: 'a;
+
+    /// Number of elements
+    fn len(&self) -> usize;
+
+    /// Immutable indexing
+    fn get(&self, i: usize) -> Option<&T>;
+
+    /// Borrowing iterator
+    fn iter(&self) -> Self::Iter<'l>;
+
+    /// Convenience
+    fn is_empty(&self) -> bool { self.len() == 0 }
+
+    fn to_any(self) -> ListAny<'l, T>
+    where
+        Self: Sized;
+}
+
+
+impl<'l, T> SeqRef<'l, T> for &'l Vec<T> {
+    type Iter<'a> = slice::Iter<'a, T> where T: 'a, Self: 'a;
+
+    fn len(&self) -> usize              { Vec::len(self) }
+    fn get(&self, i: usize) -> Option<&T> { self.as_slice().get(i) }
+    fn iter(&self) -> Self::Iter<'l>    { self.as_slice().iter() }
+    fn to_any(self) -> ListAny<'l, T>
+    where
+        Self: Sized,
+    {
+        ListAny::Vec(self)
+    }
+}
+
+
+impl<'a, T> SeqRef<'a, T> for ListView<'a, T> {
+    type Iter<'b> = Iter<'b, T> where Self: 'b, T: 'b;
+
+    fn len(&self) -> usize              { self.inner.len() }
+    fn get(&self, i: usize) -> Option<&T> { self.inner.get(i).map(debox) }
+    fn iter(&self) -> Self::Iter<'a>    { self.inner.iter().map(debox) }
+    fn to_any(self) -> ListAny<'a, T>
+    where
+        Self: Sized,
+    {
+        ListAny::View(ListView { inner:  self.inner })
+    }
+}
+
+pub enum MapAny<'a, K, V> {
+    Hash(&'a std::collections::HashMap<K, V>),   // &HashMap
+    View(MapView<'a, K, V>),               // MapView (already borrows)
+}
+
+impl<'a, K: Eq + std::hash::Hash, V> MapRef<'a, K, V>
+    for MapAny<'a, K, V>
+{
+    type Iter<'b> =
+        std::boxed::Box<dyn Iterator<Item = (&'b K, &'b V)> + 'b>
+        where Self: 'b, K: 'b, V: 'b;
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Hash(m) => m.len(),
+            Self::View(v) => v.len(),
+        }
+    }
+    fn get(&self, k: &K) -> Option<&V> {
+        match self {
+            Self::Hash(m) => m.get(k),
+            Self::View(v) => v.get(k),
+        }
+    }
+    fn iter(&self) -> Self::Iter<'_> {
+        match self {
+            Self::Hash(m) => Box::new(m.iter()),
+            Self::View(v) => Box::new(v.iter()),
+        }
+    }
+    fn to_any(self) -> MapAny<'a, K, V>
+        where
+            Self: Sized,
+             {
+        match self {
+            Self::Hash(m) => MapAny::Hash(m),
+            Self::View(v) => MapAny::View(v),
+         }
+    }
+}
+
+
+pub enum ListIter<'a, T> {
+    Vec  (std::slice::Iter<'a, T>),
+    View (ViewIter<'a, T>),
+}
+
+impl<'a, T> Iterator for ListIter<'a, T> {
+    type Item = &'a T;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Vec(it)  => it.next(),
+            Self::View(it) => it.next(),
+        }
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Self::Vec(it)  => it.size_hint(),
+            Self::View(it) => it.size_hint(),
+        }
+    }
+}
+
+impl<'a, T> ExactSizeIterator for ListIter<'a, T> {
+    fn len(&self) -> usize {
+        match self {
+            Self::Vec(it)  => it.len(),
+            Self::View(it) => it.len(),
+        }
+    }
+}
+
+pub enum ListAny<'a, T> {
+    Vec(&'a Vec<T>),                  // &Vec<T>
+    View(ListView<'a, T>),        // ListView (already borrows)
+}
+
+/* ------------------------------------------------------------------ *
+ *  SeqRef implementation
+ * ------------------------------------------------------------------ */
+impl<'a, T> SeqRef<'a, T> for ListAny<'a, T> {
+    type Iter<'x> = ListIter<'x, T> where Self: 'x, T: 'x; 
+    //type Iter<'b> =
+    //    std::boxed::Box<dyn Iterator<Item = &'b T> + ExactSizeIterator + 'b>
+    //    where Self: 'b, T: 'b;
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Vec(v)  => v.len(),
+            Self::View(v) => v.len(),
+        }
+    }
+    fn get(&self, i: usize) -> Option<&T> {
+        match self {
+            Self::Vec(v)  => v.get(i),
+            Self::View(v) => v.get(i),
+        }
+    }
+    fn iter(&self) -> Self::Iter<'a> {
+        match self {
+            Self::Vec(v)  => ListIter::Vec(v.iter()),
+            Self::View(v) => ListIter::View(v.iter()),
+        }
+    }
+    fn to_any(self) -> ListAny<'a, T>
+    where
+        Self: Sized,
+         { 
+            match self {
+                Self::Vec(v)  => ListAny::Vec(v),
+                Self::View(v) => ListAny::View(v),
+            }
+          }
+}

--- a/examples/PersonSchema/rust/src/serde_utils.rs
+++ b/examples/PersonSchema/rust/src/serde_utils.rs
@@ -1,0 +1,142 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer};
+#[cfg(feature = "serde")]
+use serde_value::{Value, ValueDeserializer};
+#[cfg(feature = "serde")]
+use serde::de::Error;
+#[cfg(feature = "serde")]
+use std::collections::{BTreeMap, HashMap};
+
+#[cfg(feature = "serde")]
+pub trait InlinedPair: Sized {
+    type Key: std::hash::Hash + Eq + serde::de::DeserializeOwned + Clone + Ord;
+    type Value: serde::de::DeserializeOwned;
+    type Error: std::fmt::Display;
+
+    fn from_pair_mapping(k: Self::Key, v: Value) -> Result<Self,Self::Error>;
+    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self,Self::Error>;
+    fn extract_key(&self) -> &Self::Key;
+}
+
+#[cfg(feature = "serde")]
+impl<T> InlinedPair for Box<T>
+where
+    T: InlinedPair + ?Sized,           // allow unsized boxes too
+{
+    type Key   = T::Key;
+    type Value = T::Value;
+    type Error = T::Error;
+
+    #[inline]
+    fn from_pair_mapping(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
+        T::from_pair_mapping(k, v).map(|x| Box::new(x))
+    }
+
+    #[inline]
+    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error>  {
+        T::from_pair_simple(k, v).map(|x| Box::new(x))
+    }
+
+    #[inline]
+    fn extract_key(&self) -> &Self::Key {
+        T::extract_key(self)
+     }
+
+}
+
+#[cfg(feature = "serde")]
+pub fn deserialize_inlined_dict_list<'de, D, T>(de: D) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: InlinedPair,
+{
+    let raw: BTreeMap<T::Key, Value> = BTreeMap::deserialize(de)?;
+    raw.into_iter().map(|(k, v)| {
+        let obj = T::from_pair_mapping(k.clone(), v).map_err(D::Error::custom)?;
+        Ok(obj)
+    }).collect()
+
+}
+
+#[cfg(feature = "serde")]
+pub fn deserialize_inlined_dict_map<'de, D, T>(
+    de: D,
+) -> Result<HashMap<T::Key, T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: InlinedPair + Deserialize<'de>,
+{
+
+    // Parse into a generic AST once
+    let ast: Value = Value::deserialize(de)?;
+
+    match ast {
+        // ---------- { key : value } form ----------
+        Value::Map(m) => {
+            let mut out = HashMap::with_capacity(m.len());
+            for (k_ast, v_ast) in m {
+                // 1) convert key and value separately
+                let key: T::Key = Deserialize::deserialize(
+                    ValueDeserializer::<D::Error>::new(k_ast)
+                ).map_err(D::Error::custom)?;
+
+
+                // ----------------- decide by the *value* shape
+                let obj = match v_ast {
+                    // ① full object (mapping) → deserialize directly
+                    Value::Map(_) => {
+                        let m: Value = Deserialize::deserialize(
+                            ValueDeserializer::<D::Error>::new(v_ast)
+                        ).map_err(D::Error::custom)?;
+                        T::from_pair_mapping(key.clone(), m).map_err(D::Error::custom)?
+                    }
+                    other => {
+                        T::from_pair_simple(key.clone(), other).map_err(D::Error::custom)?
+                    }
+                };
+
+
+                out.insert(key, obj);
+            }
+            Ok(out)
+        }
+
+        // ---------- [ value, … ] form -------------
+        Value::Seq(seq) => {
+            let mut out = HashMap::with_capacity(seq.len());
+            for v_ast in seq {
+                let val: T = Deserialize::deserialize(
+                    ValueDeserializer::<D::Error>::new(v_ast)
+                ).map_err(D::Error::custom)?;
+
+                let key = val.extract_key().clone();
+                if out.insert(key, val).is_some() {
+                    return Err(D::Error::custom("duplicate key"));
+                }
+            }
+            Ok(out)
+        }
+
+        _ => Err(D::Error::custom("expected mapping or sequence")),
+    }
+}
+
+pub fn deserialize_primitive_list_or_single_value<'de, D, T>(
+    deserializer:  D
+) -> Result<Vec<T>, D::Error> where D: Deserializer<'de>, T: Deserialize<'de> {
+    let ast: Value = Value::deserialize(deserializer)?;
+    match ast {
+        Value::Seq(seq) => {
+            seq.into_iter()
+                .map(|v| T::deserialize(ValueDeserializer::<D::Error>::new(v)))
+                .collect()
+        }
+        Value::Unit => Ok(vec![]),
+        other => {
+            let single_value: T = Deserialize::deserialize(
+                ValueDeserializer::<D::Error>::new(other)
+            ).map_err(D::Error::custom)?;
+            Ok(vec![single_value])
+        }
+    }
+}

--- a/linkml/generators/rustgen/build.py
+++ b/linkml/generators/rustgen/build.py
@@ -1,4 +1,5 @@
 from typing import Dict
+
 from linkml.generators.common.build import (
     BuildResult,
     SchemaResult,
@@ -16,10 +17,10 @@ from linkml.generators.rustgen.template import (
     RustCargo,
     RustEnum,
     RustFile,
-    RustTemplateModel,
     RustProperty,
     RustPyProject,
     RustStruct,
+    RustTemplateModel,
     RustTypeAlias,
 )
 

--- a/linkml/generators/rustgen/build.py
+++ b/linkml/generators/rustgen/build.py
@@ -65,6 +65,7 @@ class AttributeResult(RustBuildResult, SlotResult_):
     """
     A field within a rust struct
     """
+
     attribute: RustProperty
 
 

--- a/linkml/generators/rustgen/cli.py
+++ b/linkml/generators/rustgen/cli.py
@@ -27,7 +27,6 @@ def cli(
     output: Optional[Path] = None,
     **kwargs,
 ):
-
     gen = RustGenerator(yamlfile, mode=mode, pyo3=pyo3, serde=serde, output=output, crate_name=crate_name, **kwargs)
     serialized = gen.serialize(force=force)
     if output is None:

--- a/linkml/generators/rustgen/rustgen.py
+++ b/linkml/generators/rustgen/rustgen.py
@@ -497,9 +497,10 @@ class RustGenerator(Generator, LifecycleMixin):
                     return None
                 key_attr = attr
             else:
-                value_attrs.append(attr)
-                if attr.required and not attr.multivalued:
-                    value_args_no_default.append(attr)
+                if not attr.multivalued:
+                    value_attrs.append(attr)
+                    if attr.required:
+                        value_args_no_default.append(attr)
         if key_attr is not None:
             return AsKeyValue(
                 name=get_name(cls),

--- a/linkml/generators/rustgen/rustgen.py
+++ b/linkml/generators/rustgen/rustgen.py
@@ -518,6 +518,7 @@ class RustGenerator(Generator, LifecycleMixin):
             attribute=RustProperty(
                 name=get_name(attr),
                 inline_mode=inline_mode.value,
+                alias=attr.alias if attr.alias is not None and attr.alias != get_name(attr) else None,
                 container_mode=container_mode.value,
                 type_=range,
                 required=bool(attr.required),

--- a/linkml/generators/rustgen/rustgen.py
+++ b/linkml/generators/rustgen/rustgen.py
@@ -430,12 +430,12 @@ class RustGenerator(Generator, LifecycleMixin):
         attributes = self.after_generate_slots(attributes, self.schemaview)
 
         unsendable = any([a.range in self.schemaview.all_classes() for a in induced_attrs])
-
         res = ClassResult(
             source=cls,
             cls=RustStruct(
                 name=get_name(cls),
                 properties=[a.attribute for a in attributes],
+                special_case_enabled=self.schemaview.get_uri(cls, expand=True).startswith("https://w3id.org/linkml"),
                 unsendable=unsendable,
                 pyo3=self.pyo3,
                 serde=self.serde,

--- a/linkml/generators/rustgen/rustgen.py
+++ b/linkml/generators/rustgen/rustgen.py
@@ -663,7 +663,7 @@ class RustGenerator(Generator, LifecycleMixin):
         subtype_impls = []
         for sc in self.schemaview.class_descendants(cls.name):
             sco = self.schemaview.get_class(sc)
-            induced_slots = self.schemaview.class_induced_slots(cls.name)
+            induced_slots = self.schemaview.class_induced_slots(sco.name)
 
             def find_slot(n: str):
                 for s in induced_slots:
@@ -675,6 +675,7 @@ class RustGenerator(Generator, LifecycleMixin):
                 PolyTraitPropertyImpl(
                     name=get_name(a),
                     range=get_rust_range_info(sco, find_slot(a.name), self.schemaview),
+                    definition_range=get_rust_range_info(cls, a, self.schemaview),
                     struct_name=get_name(sco),
                 )
                 for a in attribs

--- a/linkml/generators/rustgen/template.py
+++ b/linkml/generators/rustgen/template.py
@@ -60,12 +60,12 @@ class RustRange(BaseModel):
         if self.containerType == ContainerType.LIST:
             if not setter:
                 # tp = f"poly_containers::ListView<{tp}>"
-                tp = f"impl poly_containers::SeqRef<{tp}>"
+                tp = f"impl poly_containers::SeqRef<'a, {tp}>"
             else:
                 tp = f"&Vec<{tp}>"
         elif self.containerType == ContainerType.MAPPING:
             if not setter:
-                tp = f"impl poly_containers::MapRef<String,{tp}>"
+                tp = f"impl poly_containers::MapRef<'a, String,{tp}>"
             else:
                 tp = f"&HashMap<String, {tp}>"
         else:

--- a/linkml/generators/rustgen/template.py
+++ b/linkml/generators/rustgen/template.py
@@ -201,6 +201,7 @@ class RustStruct(RustTemplateModel):
     """
 
     template: ClassVar[str] = "struct.rs.jinja"
+    special_case_enabled: bool = False
     class_module: Optional[RustClassModule] = None
 
     name: str

--- a/linkml/generators/rustgen/template.py
+++ b/linkml/generators/rustgen/template.py
@@ -1,9 +1,9 @@
-from typing import ClassVar, Optional, List
-
 from enum import Enum
+from typing import ClassVar, List, Optional
+
 from jinja2 import Environment, PackageLoader
 from linkml_runtime.utils.formatutils import underscore
-from pydantic import Field, computed_field, field_validator, BaseModel
+from pydantic import BaseModel, Field, computed_field, field_validator
 
 from linkml.generators.common.template import Import as Import_
 from linkml.generators.common.template import Imports as Imports_
@@ -13,6 +13,7 @@ from linkml.generators.common.template import TemplateModel, _render
 class ContainerType(Enum):
     LIST = "list"
     MAPPING = "mapping"
+
 
 class RustRange(BaseModel):
     optional: bool = False
@@ -24,7 +25,7 @@ class RustRange(BaseModel):
     has_class_subtypes: bool = False
     child_ranges: Optional[List["RustRange"]] = None
     type_: str
-    
+
     def type_for_field(self):
         tp = self.type_
         if self.has_class_subtypes:
@@ -39,8 +40,8 @@ class RustRange(BaseModel):
         if self.optional and self.containerType is None:
             tp = f"Option<{tp}>"
         return tp
-    
-    def type_for_trait(self, crateref: Optional[str], setter: bool=False):
+
+    def type_for_trait(self, crateref: Optional[str], setter: bool = False):
         tp = self.type_
         if self.is_class_range and not self.has_class_subtypes and not setter:
             if crateref and not self.is_reference:
@@ -52,7 +53,7 @@ class RustRange(BaseModel):
         convert_ref = False
         if self.containerType == ContainerType.LIST:
             if not setter:
-                #tp = f"poly_containers::ListView<{tp}>"
+                # tp = f"poly_containers::ListView<{tp}>"
                 tp = f"impl poly_containers::SeqRef<{tp}>"
             else:
                 tp = f"&Vec<{tp}>"
@@ -70,17 +71,15 @@ class RustRange(BaseModel):
                 tp = f"Option<{tp}>"
             else:
                 tp = f"&Option<{tp}>"
-        
+
         return tp
-    
-    
+
     def type_bound_for_setter(self, crateref: Optional[str]) -> Optional[str]:
         if self.is_class_range:
             tp = self.type_
             return f"Into<{tp}>"
         return None
-        
-    
+
 
 class RustTemplateModel(TemplateModel):
     """
@@ -102,6 +101,7 @@ class RustTemplateModel(TemplateModel):
     Whether serde serialization/deserialization annotations should be added.
     """
     attributes: dict[str, str] = Field(default_factory=dict)
+
 
 class PolyContainersFile(RustTemplateModel):
 
@@ -132,11 +132,11 @@ class RustProperty(RustTemplateModel):
     inline_mode: str
     container_mode: str
     name: str
-    type_: RustRange # might be a union type, so list length > 1
+    type_: RustRange  # might be a union type, so list length > 1
     required: bool
     multivalued: bool = False
     is_key_value: bool = False
-    
+
     @computed_field
     def type_for_field(self) -> str:
         """
@@ -147,12 +147,13 @@ class RustProperty(RustTemplateModel):
     @computed_field
     def hasdefault(self) -> bool:
         return self.multivalued or not self.required
-        
+
 
 class AsKeyValue(RustTemplateModel):
     """
     A key-value representation for this struct
     """
+
     template: ClassVar[str] = "as_key_value.rs.jinja"
     name: str
     key_property_name: str
@@ -162,34 +163,40 @@ class AsKeyValue(RustTemplateModel):
     can_convert_from_primitive: bool = False
     can_convert_from_empty: bool = False
 
+
 class RustStructOrSubtypeEnum(RustTemplateModel):
     template: ClassVar[str] = "struct_or_subtype_enum.rs.jinja"
     enum_name: str
-    struct_names: list[str]    
+    struct_names: list[str]
     as_key_value: bool = False
     type_designator_field: Optional[str] = None
     type_designators: dict[str, str]
+
 
 class SlotRangeAsUnion(RustTemplateModel):
     """
     A union of ranges!
     """
+
     template: ClassVar[str] = "slot_range_as_union.rs.jinja"
     slot_name: str
     ranges: list[str]
+
 
 class RustClassModule(RustTemplateModel):
     class_name: str
     class_name_snakecase: str
     template: ClassVar[str] = "class_module.rs.jinja"
     slot_ranges: List[SlotRangeAsUnion]
+
+
 class RustStruct(RustTemplateModel):
     """
     A struct!
     """
 
     template: ClassVar[str] = "struct.rs.jinja"
-    class_module : Optional[RustClassModule] = None
+    class_module: Optional[RustClassModule] = None
 
     name: str
     bases: Optional[list[str]] = None
@@ -221,7 +228,6 @@ class RustEnum(RustTemplateModel):
     items: list[str]
 
 
-
 class RustTypeAlias(RustTemplateModel):
     """
     A type alias used to represent slots
@@ -250,27 +256,26 @@ class SerdeUtilsFile(RustTemplateModel):
     template: ClassVar[str] = "serde_utils.rs.jinja"
 
 
-
 class PolyTraitProperty(RustTemplateModel):
     template: ClassVar[str] = "poly_trait_property.rs.jinja"
     name: str
     range: RustRange
-    
+
     @computed_field
     def class_range(self) -> bool:
         """
         Whether this range is a class range
         """
         return self.range.is_class_range
-    
+
     @computed_field
     def type_getter(self) -> str:
         return self.range.type_for_trait(setter=False, crateref="crate")
-    
+
     @computed_field
     def type_setter(self) -> str:
         return self.range.type_for_trait(setter=True, crateref="crate")
-    
+
     @computed_field
     def type_bound(self) -> Optional[str]:
         """
@@ -283,7 +288,8 @@ class PolyTraitPropertyImpl(RustTemplateModel):
     template: ClassVar[str] = "poly_trait_property_impl.rs.jinja"
     name: str
     range: RustRange
-    struct_name: str      
+    struct_name: str
+
     @computed_field
     def class_range(self) -> bool:
         """
@@ -297,15 +303,15 @@ class PolyTraitPropertyImpl(RustTemplateModel):
         The container type for this range, if any
         """
         return self.range.containerType.value if self.range.containerType else "None"
-    
+
     @computed_field
     def type_getter(self) -> str:
         return self.range.type_for_trait(setter=False, crateref="crate")
-    
+
     @computed_field
     def type_setter(self) -> str:
         return self.range.type_for_trait(setter=True, crateref="crate")
-    
+
     @computed_field
     def type_bound(self) -> Optional[str]:
         """
@@ -315,11 +321,12 @@ class PolyTraitPropertyImpl(RustTemplateModel):
 
 
 class PolyTraitImpl(RustTemplateModel):
-    template : ClassVar[str] = "poly_trait_impl.rs.jinja"
+    """Implementation of a :class:`PolyTrait` for a particular struct."""
+
+    template: ClassVar[str] = "poly_trait_impl.rs.jinja"
     name: str
     struct_name: str
     attrs: List[PolyTraitPropertyImpl]
-        
 
 
 class PolyTraitPropertyMatch(RustTemplateModel):
@@ -340,14 +347,20 @@ class PolyTraitPropertyMatch(RustTemplateModel):
     def type_getter(self) -> str:
         return self.range.type_for_trait(setter=False, crateref="crate")
 
+
 class PolyTraitImplForSubtypeEnum(RustTemplateModel):
+    """Trait implementation that dispatches based on subtype enums."""
+
     template: ClassVar[str] = "poly_trait_impl_orsubtype.rs.jinja"
     enum_name: str
     name: str
     attrs: List[PolyTraitPropertyMatch]
 
+
 class PolyTrait(RustTemplateModel):
-    template : ClassVar[str] = "poly_trait.rs.jinja"
+    """Definition of a polymorphic trait generated from a class hierarchy."""
+
+    template: ClassVar[str] = "poly_trait.rs.jinja"
     name: str
     attrs: List[PolyTraitProperty]
     superclass_names: List[str]
@@ -355,12 +368,12 @@ class PolyTrait(RustTemplateModel):
     subtypes: List[PolyTraitImplForSubtypeEnum]
 
 
-
 class PolyFile(RustTemplateModel):
+    """Rust file aggregating polymorphic traits."""
+
     template: ClassVar[str] = "poly.rs.jinja"
     imports: Imports = Imports()
     traits: List[PolyTrait]
-
 
 
 class RustFile(RustTemplateModel):
@@ -386,10 +399,12 @@ class RustFile(RustTemplateModel):
 class RangeEnum(RustTemplateModel):
     """
     A range enum!
-     """
+    """
+
     template: ClassVar[str] = "range_enum.rs.jinja"
     name: str
     type_: List[str]
+
 
 class RustCargo(RustTemplateModel):
     """
@@ -416,13 +431,10 @@ class RustCargo(RustTemplateModel):
                     feature_flags[i.feature_flag].append(i.module)
         return feature_flags
 
-
-
     @field_validator("name", mode="after")
     @classmethod
     def snake_case_name(cls, value: str) -> str:
         return underscore(value)
-
 
     def render(self, environment: Optional[Environment] = None, **kwargs) -> str:
         if environment is None:

--- a/linkml/generators/rustgen/template.py
+++ b/linkml/generators/rustgen/template.py
@@ -297,10 +297,6 @@ class PolyTraitPropertyImpl(RustTemplateModel):
 
     @computed_field
     def need_option_wrap(self) -> bool:
-        if self.name == 'related_to':
-            print("range:" , self.range)
-            print("def range: ", self.definition_range)
-            print("struct :  ", self.struct_name)
         return self.definition_range.optional and not self.range.optional
 
     @computed_field

--- a/linkml/generators/rustgen/template.py
+++ b/linkml/generators/rustgen/template.py
@@ -134,6 +134,7 @@ class RustProperty(RustTemplateModel):
 
     template: ClassVar[str] = "property.rs.jinja"
     inline_mode: str
+    alias: Optional[str] = None
     container_mode: str
     name: str
     type_: RustRange  # might be a union type, so list length > 1

--- a/linkml/generators/rustgen/templates/anything.rs.jinja
+++ b/linkml/generators/rustgen/templates/anything.rs.jinja
@@ -1,0 +1,53 @@
+#[derive(Clone, PartialEq)]
+pub struct Anything(
+    #[cfg(feature = "serde")] pub serde_value::Value,
+    #[cfg(not(feature = "serde"))] pub (),
+);
+
+
+#[cfg(feature = "serde")]
+impl Serialize for Anything {
+    fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
+    where S: serde::Serializer {
+        self.0.serialize(ser)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Anything {
+    fn deserialize<D>(de: D) -> Result<Self, D::Error>
+    where D: serde::Deserializer<'de> {
+        <serde_value::Value as Deserialize>::deserialize(de).map(Anything)
+    }
+}
+
+#[cfg(all(feature = "pyo3", feature = "serde"))]
+impl<'py> FromPyObject<'py> for Anything {
+    fn extract_bound(_obj: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        // todo actually implement this. will need pythonize dependency
+        Ok(Anything(serde_value::Value::Unit))
+    }
+}
+
+/* ---------- getter side ---------- */
+#[cfg(all(feature = "pyo3", feature = "serde"))]
+impl<'py> IntoPyObject<'py> for Anything {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        // todo actually implement this. will need pythonize dependency
+        Ok(py.None().into_bound(py))
+    }
+}
+
+impl std::fmt::Debug for Anything {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[cfg(feature = "serde")]
+        return write!(f, "Anything({:?})", self.0);
+
+        #[cfg(not(feature = "serde"))]
+        return f.write_str("Anything(<opaque>)");
+    }
+}

--- a/linkml/generators/rustgen/templates/poly_trait_property.rs.jinja
+++ b/linkml/generators/rustgen/templates/poly_trait_property.rs.jinja
@@ -1,4 +1,5 @@
-    fn {{ name }}(&self) -> {{ type_getter }};
+{% set lifetime_needed = range.box_needed or range.containerType %}
+    fn {{ name }}{% if lifetime_needed %}<'a>{% endif %}(&{% if lifetime_needed %}'a {% endif %}self) -> {{ type_getter }};
     // fn {{ name }}_mut(&mut self) -> &mut {{ type_getter }};
 {% if type_bound %}
     // fn set_{{ name }}<E>(&mut self, value: {{ type_setter }}) where E: {{ type_bound }};

--- a/linkml/generators/rustgen/templates/poly_trait_property.rs.jinja
+++ b/linkml/generators/rustgen/templates/poly_trait_property.rs.jinja
@@ -1,4 +1,4 @@
-{% set lifetime_needed = range.box_needed or range.containerType %}
+{% set lifetime_needed = range.containerType %}
     fn {{ name }}{% if lifetime_needed %}<'a>{% endif %}(&{% if lifetime_needed %}'a {% endif %}self) -> {{ type_getter }};
     // fn {{ name }}_mut(&mut self) -> &mut {{ type_getter }};
 {% if type_bound %}

--- a/linkml/generators/rustgen/templates/poly_trait_property_impl.rs.jinja
+++ b/linkml/generators/rustgen/templates/poly_trait_property_impl.rs.jinja
@@ -12,8 +12,10 @@
 {% if range.optional %}
         {% if type_getter == 'Option<&str>' %}
         return self.{{ name }}.as_deref();
-        {% else %}
+        {% elif ct != 'list' and ct != 'mapping' %}
         return self.{{ name }}.as_ref();
+        {% else %}
+        return &self.{{ name }};
         {% endif %}
 {% else %}
 {% if need_option_wrap %}

--- a/linkml/generators/rustgen/templates/poly_trait_property_impl.rs.jinja
+++ b/linkml/generators/rustgen/templates/poly_trait_property_impl.rs.jinja
@@ -9,10 +9,18 @@
         return self.{{ name }}.as_deref();
 {% endif %}
 {% else %}
-{% if range.optional and range.is_class_range and not range.is_reference and ct == 'None' %}
+{% if range.optional %}
+        {% if type_getter == 'Option<&str>' %}
+        return self.{{ name }}.as_deref();
+        {% else %}
         return self.{{ name }}.as_ref();
+        {% endif %}
+{% else %}
+{% if need_option_wrap %}
+        return Some(&self.{{ name }});
 {% else %}
         return &self.{{ name }};
+{% endif %}
 {% endif %}
 {% endif %}
     }

--- a/linkml/generators/rustgen/templates/poly_trait_property_impl.rs.jinja
+++ b/linkml/generators/rustgen/templates/poly_trait_property_impl.rs.jinja
@@ -1,10 +1,19 @@
     fn {{ name}}(&self) -> {{ type_getter }} {
 {%  if range.box_needed %}
-// {{ ct }}
 {% if ct == 'list' %}
+        {% if range.optional %}
+        return self.{{ name }}.as_ref().map(|x| poly_containers::ListView::new(x));
+        {% else %}
         return poly_containers::ListView::new(&self.{{ name }});
+        {% endif %}
 {% elif ct == "mapping" %}
+        {% if range.optional %}
+        return self.{{ name}}
+                .as_ref()
+                .map(poly_containers::MapView::new);
+        {% else %}
         return poly_containers::MapView::new(&self.{{ name }});
+        {% endif %}
 {% else %}
         return self.{{ name }}.as_deref();
 {% endif %}
@@ -15,7 +24,7 @@
         {% elif ct != 'list' and ct != 'mapping' %}
         return self.{{ name }}.as_ref();
         {% else %}
-        return &self.{{ name }};
+        return self.{{ name }}.as_ref();
         {% endif %}
 {% else %}
 {% if need_option_wrap %}

--- a/linkml/generators/rustgen/templates/poly_trait_property_impl.rs.jinja
+++ b/linkml/generators/rustgen/templates/poly_trait_property_impl.rs.jinja
@@ -1,4 +1,5 @@
-    fn {{ name}}(&self) -> {{ type_getter }} {
+{% set lifetime_needed = range.box_needed or range.containerType %}
+    fn {{ name}}{% if lifetime_needed %}<'a>{% endif %}(&{% if lifetime_needed %}'a {% endif %}self) -> {{ type_getter }} {
 {%  if range.box_needed %}
 {% if ct == 'list' %}
         {% if range.optional %}

--- a/linkml/generators/rustgen/templates/poly_trait_property_impl.rs.jinja
+++ b/linkml/generators/rustgen/templates/poly_trait_property_impl.rs.jinja
@@ -1,4 +1,4 @@
-{% set lifetime_needed = range.box_needed or range.containerType %}
+{% set lifetime_needed = range.containerType %}
     fn {{ name}}{% if lifetime_needed %}<'a>{% endif %}(&{% if lifetime_needed %}'a {% endif %}self) -> {{ type_getter }} {
 {%  if range.box_needed %}
 {% if ct == 'list' %}

--- a/linkml/generators/rustgen/templates/poly_trait_property_impl.rs.jinja
+++ b/linkml/generators/rustgen/templates/poly_trait_property_impl.rs.jinja
@@ -15,14 +15,22 @@
         return poly_containers::MapView::new(&self.{{ name }});
         {% endif %}
 {% else %}
+        {% if is_copy %}
+        return self.{{ name }};
+        {% else %}
         return self.{{ name }}.as_deref();
+        {% endif %}
 {% endif %}
 {% else %}
 {% if range.optional %}
         {% if type_getter == 'Option<&str>' %}
         return self.{{ name }}.as_deref();
         {% elif ct != 'list' and ct != 'mapping' %}
+        {% if is_copy %}
+        return self.{{ name }};
+        {% else %}
         return self.{{ name }}.as_ref();
+        {% endif %}
         {% else %}
         return self.{{ name }}.as_ref();
         {% endif %}

--- a/linkml/generators/rustgen/templates/poly_trait_property_match.rs.jinja
+++ b/linkml/generators/rustgen/templates/poly_trait_property_match.rs.jinja
@@ -1,4 +1,4 @@
-{% set lifetime_needed = range.box_needed or range.containerType %}
+{% set lifetime_needed = range.containerType %}
     fn {{ name}}{% if lifetime_needed %}<'a>{% endif %}(&{% if lifetime_needed %}'a {% endif %}self) -> {{ type_getter }} {
         match self {
             {% for c in cases %}

--- a/linkml/generators/rustgen/templates/poly_trait_property_match.rs.jinja
+++ b/linkml/generators/rustgen/templates/poly_trait_property_match.rs.jinja
@@ -1,4 +1,5 @@
-    fn {{ name}}(&self) -> {{ type_getter }} {
+{% set lifetime_needed = range.box_needed or range.containerType %}
+    fn {{ name}}{% if lifetime_needed %}<'a>{% endif %}(&{% if lifetime_needed %}'a {% endif %}self) -> {{ type_getter }} {
         match self {
             {% for c in cases %}
                 {{ struct_name }}::{{c}}(val) => val.{{name}}(){% if is_container %}{% if is_optional %}.map(|x| x.to_any()){% else %}.to_any(){% endif %}{% endif %},

--- a/linkml/generators/rustgen/templates/poly_trait_property_match.rs.jinja
+++ b/linkml/generators/rustgen/templates/poly_trait_property_match.rs.jinja
@@ -1,7 +1,7 @@
     fn {{ name}}(&self) -> {{ type_getter }} {
         match self {
             {% for c in cases %}
-                {{ struct_name }}::{{c}}(val) => val.{{name}}(){% if is_container %}.to_any(){% endif %},
+                {{ struct_name }}::{{c}}(val) => val.{{name}}(){% if is_container %}{% if is_optional %}.map(|x| x.to_any()){% else %}.to_any(){% endif %}{% endif %},
             {% endfor %}
 
         }

--- a/linkml/generators/rustgen/templates/property.rs.jinja
+++ b/linkml/generators/rustgen/templates/property.rs.jinja
@@ -10,4 +10,7 @@
 {% if hasdefault %}
 #[cfg_attr(feature = "serde", serde(default))]
 {% endif %}
+{% if alias %}
+#[cfg_attr(feature = "serde", serde(alias = "{{ alias }}"))]
+{% endif %}
 pub {{ name }}: {{ type_for_field }}

--- a/linkml/generators/rustgen/templates/property.rs.jinja
+++ b/linkml/generators/rustgen/templates/property.rs.jinja
@@ -1,3 +1,6 @@
+{% if generate_merge %}
+#[merge({{ merge_strategy }})]
+{% endif %}
 {%- if is_key_value -%}
 {% if container_mode == "list" and inline_mode == "inline" %}
 #[cfg_attr(feature = "serde", serde(deserialize_with = "serde_utils::deserialize_inlined_dict_list{% if recursive %}_box{% endif %}"))]

--- a/linkml/generators/rustgen/templates/property.rs.jinja
+++ b/linkml/generators/rustgen/templates/property.rs.jinja
@@ -3,13 +3,13 @@
 {% endif %}
 {%- if is_key_value -%}
 {% if container_mode == "list" and inline_mode == "inline" %}
-#[cfg_attr(feature = "serde", serde(deserialize_with = "serde_utils::deserialize_inlined_dict_list{% if recursive %}_box{% endif %}"))]
+#[cfg_attr(feature = "serde", serde(deserialize_with = "serde_utils::deserialize_inlined_dict_list{% if optional %}_optional{% endif %}{% if recursive %}_box{% endif %}"))]
 {% elif container_mode == "mapping" and inline_mode == "inline" %}
-#[cfg_attr(feature = "serde", serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map{% if recursive %}_box{% endif %}"))]
+#[cfg_attr(feature = "serde", serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map{% if optional %}_optional{% endif %}{% if recursive %}_box{% endif %}"))]
 {% endif %}
 {% elif container_mode == "list" and inline_mode == "primitive" %}
-#[cfg_attr(feature = "serde", serde(deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value"))]
-{%- endif -%}
+#[cfg_attr(feature = "serde", serde(deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value{% if optional %}_optional{% endif %}"))]
+{% endif -%}
 {% if hasdefault %}
 #[cfg_attr(feature = "serde", serde(default))]
 {% endif %}

--- a/linkml/generators/rustgen/templates/serde_utils.rs.jinja
+++ b/linkml/generators/rustgen/templates/serde_utils.rs.jinja
@@ -121,6 +121,26 @@ where
     }
 }
 
+#[cfg(feature = "serde")]
+pub fn deserialize_inlined_dict_map_optional<'de, D, T>(
+    de: D,
+) -> Result<Option<HashMap<T::Key, T>>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: InlinedPair + Deserialize<'de>,
+{
+    let ast: Value = Value::deserialize(de)?;
+    match ast {
+        Value::Unit => Ok(None),
+        Value::Map(_) | Value::Seq(_) => {
+            let map = deserialize_inlined_dict_map(ValueDeserializer::<D::Error>::new(ast))?;
+            Ok(Some(map))
+        }
+        _ => Err(D::Error::custom("expected mapping, sequence, or unit")),
+    }
+}
+
+
 pub fn deserialize_primitive_list_or_single_value<'de, D, T>(
     deserializer:  D
 ) -> Result<Vec<T>, D::Error> where D: Deserializer<'de>, T: Deserialize<'de> {
@@ -137,6 +157,20 @@ pub fn deserialize_primitive_list_or_single_value<'de, D, T>(
                 ValueDeserializer::<D::Error>::new(other)
             ).map_err(D::Error::custom)?;
             Ok(vec![single_value])
+        }
+    }
+}
+
+
+pub fn deserialize_primitive_list_or_single_value_optional<'de, D, T>(
+    deserializer:  D
+) -> Result<Option<Vec<T>>, D::Error> where D: Deserializer<'de>, T: Deserialize<'de> {
+    let ast: Value = Value::deserialize(deserializer)?;
+    match ast {
+        Value::Unit => Ok(None),
+        _ => {
+            let d = deserialize_primitive_list_or_single_value(ValueDeserializer::<D::Error>::new(ast))?;
+            Ok(Some(d))
         }
     }
 }

--- a/linkml/generators/rustgen/templates/struct.rs.jinja
+++ b/linkml/generators/rustgen/templates/struct.rs.jinja
@@ -7,6 +7,9 @@
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+{% if generate_merge %}
+#[derive(Merge)]
+{% endif %}
 pub struct {{ name }} {
 {% for property in properties %}
 {% filter indent(width=4, first=True, blank=False) %}

--- a/linkml/generators/rustgen/templates/struct.rs.jinja
+++ b/linkml/generators/rustgen/templates/struct.rs.jinja
@@ -1,3 +1,6 @@
+{% if special_case_enabled and name == 'Anything' %}
+{% include 'anything.rs.jinja' %}
+{% else %}
 {% if class_module %}
 {{ class_module }}
 {% endif %}
@@ -50,4 +53,5 @@ impl<'py> FromPyObject<'py> for Box<{{ name }}> {
 {% endif %}
 {% if struct_or_subtype_enum %}
 {{ struct_or_subtype_enum }}
+{% endif %}
 {% endif %}

--- a/linkml/generators/rustgen/templates/struct.rs.jinja
+++ b/linkml/generators/rustgen/templates/struct.rs.jinja
@@ -1,5 +1,7 @@
 {% if special_case_enabled and name == 'Anything' %}
 {% include 'anything.rs.jinja' %}
+{% elif special_case_enabled and name == 'AnyValue' %}
+pub type AnyValue = Anything;
 {% else %}
 {% if class_module %}
 {{ class_module }}
@@ -53,8 +55,8 @@ impl<'py> FromPyObject<'py> for Box<{{ name }}> {
 
 {% if generate_merge %}
 impl {{ name }} {
-    pub fn merge_with(&mut self, other: {{ name }}) {
-        self.merge(other)
+    pub fn merge_with(&mut self, other: &{{ name }}) {
+        self.merge(other.clone())
     }
 }
 {% endif %}

--- a/linkml/generators/rustgen/templates/struct.rs.jinja
+++ b/linkml/generators/rustgen/templates/struct.rs.jinja
@@ -50,6 +50,15 @@ impl<'py> FromPyObject<'py> for Box<{{ name }}> {
         ))
     }
 }
+
+{% if generate_merge %}
+impl {{ name }} {
+    pub fn merge_with(&mut self, other: {{ name }}) {
+        self.merge(other)
+    }
+}
+{% endif %}
+
 {% endif %}
 {% if as_key_value %}
 {{ as_key_value }}

--- a/linkml/generators/rustgen/templates/struct_or_subtype_enum.rs.jinja
+++ b/linkml/generators/rustgen/templates/struct_or_subtype_enum.rs.jinja
@@ -1,9 +1,9 @@
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 {% if type_designator_field %}
-#[serde(tag = "{{ type_designator_field }}")]
+#[cfg_attr(feature="serde", serde(tag = "{{ type_designator_field }}"))]
 {% else %}
-#[serde(untagged)]
+#[cfg_attr(feature="serde", serde(untagged))]
 {% endif %}
 pub enum {{ enum_name }} {
 {%- for t in struct_names -%}

--- a/tests/test_generators/test_rustgen.py
+++ b/tests/test_generators/test_rustgen.py
@@ -1,9 +1,43 @@
 import pytest
+from linkml_runtime.utils.schemaview import SchemaView
 
 from linkml.generators.rustgen import RustGenerator
+from linkml.generators.rustgen.rustgen import (
+    SlotContainerMode,
+    SlotInlineMode,
+    determine_slot_mode,
+)
 
 
 @pytest.mark.rustgen
 def test_generate_crate(kitchen_sink_path, temp_dir):
     gen = RustGenerator(kitchen_sink_path, mode="crate", output=temp_dir)
     _ = gen.serialize(force=True)
+
+
+def test_determine_slot_mode(kitchen_sink_path):
+    sv = SchemaView(kitchen_sink_path)
+
+    age_slot = sv.get_slot("age in years")
+    assert determine_slot_mode(age_slot, sv) == (
+        SlotContainerMode.SINGLE_VALUE,
+        SlotInlineMode.PRIMITIVE,
+    )
+
+    aliases_slot = sv.get_slot("aliases")
+    assert determine_slot_mode(aliases_slot, sv) == (
+        SlotContainerMode.LIST,
+        SlotInlineMode.PRIMITIVE,
+    )
+
+    hist_slot = sv.get_slot("has employment history")
+    assert determine_slot_mode(hist_slot, sv) == (
+        SlotContainerMode.LIST,
+        SlotInlineMode.INLINE,
+    )
+
+    employed_slot = sv.get_slot("employed at")
+    assert determine_slot_mode(employed_slot, sv) == (
+        SlotContainerMode.SINGLE_VALUE,
+        SlotInlineMode.REFERENCE,
+    )


### PR DESCRIPTION
* add rst documentation (can't test it myself if mdbook works) as discused
* add generated rust crate for personinfo example.
* make poly traits more ergonomic, no more `&Option<String>` return types but more idiomatic `Option<&str>`, better abstracting over the internally used data types.
* support slot aliases
* add rust implementation for the Anything type.
* fix warnings with newer rust versions